### PR TITLE
Notify string

### DIFF
--- a/Parser.js
+++ b/Parser.js
@@ -612,6 +612,7 @@ class Parser extends BaseParser {
 
         function endString() {
             var string = endPart();
+            string.value = notifiers.notifyString(string);
             string.parentState.string(string);
         }
 

--- a/README.md
+++ b/README.md
@@ -75,6 +75,14 @@ var parser = require('htmljs-parser').createParser({
         var pos = event.pos; // Integer
     },
 
+    onString: function(event) {
+        // Text within ""
+        var value = event.value; // String
+        var stringParts = event.stringParts; // Array
+        var isStringLiteral = event.isStringLiteral // Boolean
+        var pos = event.pos; // Integer
+    },
+
     onCDATA: function(event) {
         // <![CDATA[<value>]]>
         var value = event.value; // String

--- a/notify-util.js
+++ b/notify-util.js
@@ -282,6 +282,29 @@ exports.createNotifiers = function(parser, listeners) {
             return placeholder.value;
         },
 
+        notifyString(string) {
+            if (hasError) {
+                return;
+            }
+
+            var eventFunc = listeners.onString;
+            if (eventFunc) {
+                var stringEvent = {
+                    type: 'string',
+                    value: string.value,
+                    pos: string.pos,
+                    endPos: string.endPos,
+                    stringParts: string.stringParts,
+                    isStringLiteral: string.isStringLiteral
+                };
+
+                eventFunc.call(parser, stringEvent, parser);
+                return stringEvent.value;
+            }
+
+            return string.value;
+        },
+
         notifyFinish() {
             if (listeners.onfinish) {
                 listeners.onfinish.call(parser, {}, parser);

--- a/test/autotest-1.x/argument-tag-complex/expected.html
+++ b/test/autotest-1.x/argument-tag-complex/expected.html
@@ -1,2 +1,2 @@
-<for(x in [("Hello "+($escapeXml($withinString(name)))+"!"), "(World)"])>
+<for(x in [$placeholderString(("Hello "+($escapeXml($withinString(name)))+"!")), "(World)"])>
 </for>

--- a/test/autotest-1.x/placeholder-attr-string-value-mixed-quotes/expected.html
+++ b/test/autotest-1.x/placeholder-attr-string-value-mixed-quotes/expected.html
@@ -1,3 +1,3 @@
-<custom name=($escapeXml($withinString('some text')))>
+<custom name=$placeholderString(($escapeXml($withinString('some text'))))>
     text:"TEST"
 </custom>

--- a/test/autotest-1.x/placeholder-attr-string-value-parens/expected.html
+++ b/test/autotest-1.x/placeholder-attr-string-value-parens/expected.html
@@ -1,3 +1,3 @@
-<custom name=(("Hello "+($escapeXml($withinString(name)))+"!"))>
+<custom name=($placeholderString(("Hello "+($escapeXml($withinString(name)))+"!")))>
     text:"TEST"
 </custom>

--- a/test/autotest-1.x/placeholder-attr-string-value/expected.html
+++ b/test/autotest-1.x/placeholder-attr-string-value/expected.html
@@ -1,3 +1,3 @@
-<custom name=("Hello "+($escapeXml($withinString(name)))+"!")>
+<custom name=$placeholderString(("Hello "+($escapeXml($withinString(name)))+"!"))>
     text:"TEST"
 </custom>

--- a/test/autotest-1.x/placeholder-attr-within-placeholder/expected.html
+++ b/test/autotest-1.x/placeholder-attr-within-placeholder/expected.html
@@ -1,2 +1,2 @@
-<custom data=($escapeXml($withinString(("Hello "+($escapeXml($withinString(data.firstName + data.lastName)))))))>
+<custom data=$placeholderString(($escapeXml($withinString($placeholderString(("Hello "+($escapeXml($withinString(data.firstName + data.lastName)))))))))>
 </custom>

--- a/test/autotest-1.x/placeholder-attr-within-string-complex/expected.html
+++ b/test/autotest-1.x/placeholder-attr-within-string-complex/expected.html
@@ -1,2 +1,2 @@
-<custom data=(("Hello "+($noEscapeXml($withinString(name)))+"!") + " This is a test.")>
+<custom data=($placeholderString(("Hello "+($noEscapeXml($withinString(name)))+"!")) + " This is a test.")>
 </custom>

--- a/test/autotest-1.x/placeholder-attr-within-string-simple/expected.html
+++ b/test/autotest-1.x/placeholder-attr-within-string-simple/expected.html
@@ -1,2 +1,2 @@
-<custom data=($escapeXml($withinString(abc)))>
+<custom data=$placeholderString(($escapeXml($withinString(abc))))>
 </custom>

--- a/test/autotest-1.x/placeholder-attr-wrapped/expected.html
+++ b/test/autotest-1.x/placeholder-attr-wrapped/expected.html
@@ -1,2 +1,2 @@
-<custom data=($escapeXml($withinString(abc)))>
+<custom data=$placeholderString(($escapeXml($withinString(abc))))>
 </custom>

--- a/test/autotest-1.x/placeholder-backslash/expected.html
+++ b/test/autotest-1.x/placeholder-backslash/expected.html
@@ -1,4 +1,4 @@
-<foo a="${test" b=("\"+($escapeXml($withinString(test)))) c="$!{test" d=("\"+($noEscapeXml($withinString(test))))>
+<foo a="${test" b=$placeholderString(("\"+($escapeXml($withinString(test))))) c="$!{test" d=$placeholderString(("\"+($noEscapeXml($withinString(test)))))>
     text:"\n\n"
 </foo>
 text:"\n"

--- a/test/autotest-1.x/placeholder-escape/expected.html
+++ b/test/autotest-1.x/placeholder-escape/expected.html
@@ -1,4 +1,4 @@
-<custom name=("Hello "+($escapeXml($withinString(name)))+"!")>
+<custom name=$placeholderString(("Hello "+($escapeXml($withinString(name)))+"!"))>
     text:"\n    Hello "
     ${"$escapeXml(name)"}
     text:"!\n"

--- a/test/autotest-1.x/placeholder-no-escape/expected.html
+++ b/test/autotest-1.x/placeholder-no-escape/expected.html
@@ -1,4 +1,4 @@
-<custom name=("Hello "+($noEscapeXml($withinString(name)))+"!")>
+<custom name=$placeholderString(("Hello "+($noEscapeXml($withinString(name)))+"!"))>
     text:"\n    Hello "
     $!{"$noEscapeXml(name)"}
     text:"!\n"

--- a/test/autotest-1.x/placeholder-within-placeholder-escaping/expected.html
+++ b/test/autotest-1.x/placeholder-within-placeholder-escaping/expected.html
@@ -1,1 +1,1 @@
-$!{"$noEscapeXml((\"Hello \"+($escapeXml($withinString(data.name)))+\"!\"))"}
+$!{"$noEscapeXml($placeholderString((\"Hello \"+($escapeXml($withinString(data.name)))+\"!\")))"}

--- a/test/autotest-1.x/placeholder-within-placeholder/expected.html
+++ b/test/autotest-1.x/placeholder-within-placeholder/expected.html
@@ -1,1 +1,1 @@
-${"$escapeXml((\"Hello \"+($escapeXml($withinString(data.name)))+\"!\"))"}
+${"$escapeXml($placeholderString((\"Hello \"+($escapeXml($withinString(data.name)))+\"!\")))"}

--- a/test/autotest-1.x/placeholder-within-string-newlines/expected.html
+++ b/test/autotest-1.x/placeholder-within-string-newlines/expected.html
@@ -1,4 +1,4 @@
-<custom data=($escapeXml($withinString(
+<custom data=$placeholderString(($escapeXml($withinString(
 abc
-)))>
+))))>
 </custom>

--- a/test/autotest/argument-tag-complex/expected.html
+++ b/test/autotest/argument-tag-complex/expected.html
@@ -1,2 +1,2 @@
-<for(x in [("Hello "+($escapeXml($withinString(name)))+"!"), "(World)"])>
+<for(x in [$placeholderString(("Hello "+($escapeXml($withinString(name)))+"!")), "(World)"])>
 </for>

--- a/test/autotest/placeholder-attr-string-value-mixed-quotes/expected.html
+++ b/test/autotest/placeholder-attr-string-value-mixed-quotes/expected.html
@@ -1,3 +1,3 @@
-<custom name=($escapeXml($withinString('some text')))>
+<custom name=$placeholderString(($escapeXml($withinString('some text'))))>
     text:"TEST"
 </custom>

--- a/test/autotest/placeholder-attr-string-value-parens/expected.html
+++ b/test/autotest/placeholder-attr-string-value-parens/expected.html
@@ -1,3 +1,3 @@
-<custom name=(("Hello "+($escapeXml($withinString(name)))+"!"))>
+<custom name=($placeholderString(("Hello "+($escapeXml($withinString(name)))+"!")))>
     text:"TEST"
 </custom>

--- a/test/autotest/placeholder-attr-string-value/expected.html
+++ b/test/autotest/placeholder-attr-string-value/expected.html
@@ -1,3 +1,3 @@
-<custom name=("Hello "+($escapeXml($withinString(name)))+"!")>
+<custom name=$placeholderString(("Hello "+($escapeXml($withinString(name)))+"!"))>
     text:"TEST"
 </custom>

--- a/test/autotest/placeholder-attr-within-placeholder/expected.html
+++ b/test/autotest/placeholder-attr-within-placeholder/expected.html
@@ -1,2 +1,2 @@
-<custom data=($escapeXml($withinString(("Hello "+($escapeXml($withinString(data.firstName + data.lastName)))))))>
+<custom data=$placeholderString(($escapeXml($withinString($placeholderString(("Hello "+($escapeXml($withinString(data.firstName + data.lastName)))))))))>
 </custom>

--- a/test/autotest/placeholder-attr-within-string-complex/expected.html
+++ b/test/autotest/placeholder-attr-within-string-complex/expected.html
@@ -1,2 +1,2 @@
-<custom data=(("Hello "+($noEscapeXml($withinString(name)))+"!") + " This is a test.")>
+<custom data=($placeholderString(("Hello "+($noEscapeXml($withinString(name)))+"!")) + " This is a test.")>
 </custom>

--- a/test/autotest/placeholder-attr-within-string-simple/expected.html
+++ b/test/autotest/placeholder-attr-within-string-simple/expected.html
@@ -1,2 +1,2 @@
-<custom data=($escapeXml($withinString(abc)))>
+<custom data=$placeholderString(($escapeXml($withinString(abc))))>
 </custom>

--- a/test/autotest/placeholder-attr-wrapped/expected.html
+++ b/test/autotest/placeholder-attr-wrapped/expected.html
@@ -1,2 +1,2 @@
-<custom data=($escapeXml($withinString(abc)))>
+<custom data=$placeholderString(($escapeXml($withinString(abc))))>
 </custom>

--- a/test/autotest/placeholder-backslash/expected.html
+++ b/test/autotest/placeholder-backslash/expected.html
@@ -1,4 +1,4 @@
-<foo a="${test" b=("\"+($escapeXml($withinString(test)))) c="$!{test" d=("\"+($noEscapeXml($withinString(test))))>
+<foo a="${test" b=$placeholderString(("\"+($escapeXml($withinString(test))))) c="$!{test" d=$placeholderString(("\"+($noEscapeXml($withinString(test)))))>
     text:"\n\n"
 </foo>
 text:"\n"

--- a/test/autotest/placeholder-escape/expected.html
+++ b/test/autotest/placeholder-escape/expected.html
@@ -1,4 +1,4 @@
-<custom name=("Hello "+($escapeXml($withinString(name)))+"!")>
+<custom name=$placeholderString(("Hello "+($escapeXml($withinString(name)))+"!"))>
     text:"\n    Hello "
     ${"$escapeXml(name)"}
     text:"!\n"

--- a/test/autotest/placeholder-no-escape/expected.html
+++ b/test/autotest/placeholder-no-escape/expected.html
@@ -1,4 +1,4 @@
-<custom name=("Hello "+($noEscapeXml($withinString(name)))+"!")>
+<custom name=$placeholderString(("Hello "+($noEscapeXml($withinString(name)))+"!"))>
     text:"\n    Hello "
     $!{"$noEscapeXml(name)"}
     text:"!\n"

--- a/test/autotest/placeholder-within-placeholder-escaping/expected.html
+++ b/test/autotest/placeholder-within-placeholder-escaping/expected.html
@@ -1,1 +1,1 @@
-$!{"$noEscapeXml((\"Hello \"+($escapeXml($withinString(data.name)))+\"!\"))"}
+$!{"$noEscapeXml($placeholderString((\"Hello \"+($escapeXml($withinString(data.name)))+\"!\")))"}

--- a/test/autotest/placeholder-within-placeholder/expected.html
+++ b/test/autotest/placeholder-within-placeholder/expected.html
@@ -1,1 +1,1 @@
-${"$escapeXml((\"Hello \"+($escapeXml($withinString(data.name)))+\"!\"))"}
+${"$escapeXml($placeholderString((\"Hello \"+($escapeXml($withinString(data.name)))+\"!\")))"}

--- a/test/autotest/placeholder-within-string-newlines/expected.html
+++ b/test/autotest/placeholder-within-string-newlines/expected.html
@@ -1,4 +1,4 @@
-<custom data=($escapeXml($withinString(
+<custom data=$placeholderString(($escapeXml($withinString(
 abc
-)))>
+))))>
 </custom>

--- a/test/util/TreeBuilder.js
+++ b/test/util/TreeBuilder.js
@@ -185,6 +185,12 @@ class TreeBuilder {
                 this.last.children.push(new Node(event));
             },
 
+            onString: (event) => {
+                if (!event.isStringLiteral) {
+                    event.value = '$placeholderString(' + event.value + ')';
+                }
+            },
+
             onPlaceholder: (event) => {
                 var escape = event.escape;
                 var withinString = event.withinString;

--- a/test/util/runDirTest.js
+++ b/test/util/runDirTest.js
@@ -86,22 +86,13 @@ module.exports = function(dir, parserOptions) {
 
         if (suffix === '.json') {
             var expectedObject = JSON.parse(expected);
-
-            try {
-                assert.deepEqual(
-                    actual,
-                    expectedObject);
-            } catch(e) {
-                // console.error('Unexpected output for "' + name + '":\nEXPECTED (' + expectedPath + '):\n---------\n' + expectedJSON +
-                //     '\n---------\nACTUAL (' + actualPath + '):\n---------\n' + actualJSON + '\n---------');
-                throw new Error('Unexpected output for "' + name + '"');
-            }
+            assert.deepEqual(actual, expectedObject);
         } else {
             if (actual !== expected) {
                 if (updateExpectations) {
                     fs.writeFileSync(expectedPath, actual, { encoding: 'utf8' });
                 } else {
-                    throw new Error('Unexpected output for "' + name + '"');
+                    assert.deepEqual(actual, expected);
                 }
             }
         }


### PR DESCRIPTION
Adds an extra hook to notify a user of the parser when a string is parsed.  This allows determining when a placeholder string is used rather than just getting a binary expression.