### PR TITLE
template literals:preserve newline literals and parse placeholders

### DIFF
--- a/test/autotest-1.x/backtick-string/expected.html
+++ b/test/autotest-1.x/backtick-string/expected.html
@@ -1,2 +1,3 @@
-<hello message=`Hello\n    ${foo}!`>
+<hello message=`Hello
+    ${foo}!`>
 </hello>

--- a/test/autotest/backtick-string-nested-with-space/expected.html
+++ b/test/autotest/backtick-string-nested-with-space/expected.html
@@ -1,0 +1,2 @@
+<hello message=`${`hi ${name}`}!`>
+</hello>

--- a/test/autotest/backtick-string-nested-with-space/input.htmljs
+++ b/test/autotest/backtick-string-nested-with-space/input.htmljs
@@ -1,0 +1,1 @@
+<hello message=`${`hi ${name}`}!`></hello>

--- a/test/autotest/backtick-string-placeholder-newline/expected.html
+++ b/test/autotest/backtick-string-placeholder-newline/expected.html
@@ -1,0 +1,4 @@
+<hello message=`${
+    foo
+}!`>
+</hello>

--- a/test/autotest/backtick-string-placeholder-newline/input.htmljs
+++ b/test/autotest/backtick-string-placeholder-newline/input.htmljs
@@ -1,0 +1,3 @@
+<hello message=`${
+    foo
+}!`></hello>

--- a/test/autotest/backtick-string/expected.html
+++ b/test/autotest/backtick-string/expected.html
@@ -1,2 +1,3 @@
-<hello message=`Hello\n    ${foo}!`>
+<hello message=`Hello
+    ${foo}!`>
 </hello>


### PR DESCRIPTION
The following now parse properly:

```marko
// previously threw an error
<hello message=`${`hi ${name}`}!`></hello>
```

```marko
// previously parsed, but incorrectly included 
// newline escape sequences in the interpolated js
<hello message=`${
    foo
}!`></hello>
```