### PR TITLE
reset indent on new-line

### DIFF
--- a/Parser.js
+++ b/Parser.js
@@ -1288,6 +1288,7 @@ class Parser extends BaseParser {
 
             eol(newLine) {
                 text += newLine;
+                indent = '';
             },
 
             eof: htmlEOF,

--- a/test/autotest/whitespace-only-reset-indent/expected.html
+++ b/test/autotest/whitespace-only-reset-indent/expected.html
@@ -1,0 +1,5 @@
+<div>
+</div>
+text:"\n"
+<span>
+</span>

--- a/test/autotest/whitespace-only-reset-indent/expected.html
+++ b/test/autotest/whitespace-only-reset-indent/expected.html
@@ -1,4 +1,5 @@
 <div>
+    text:"The next line has spaces on it"
 </div>
 text:"\n"
 <span>

--- a/test/autotest/whitespace-only-reset-indent/input.htmljs
+++ b/test/autotest/whitespace-only-reset-indent/input.htmljs
@@ -1,3 +1,3 @@
-div
-     
+div -- The next line has spaces on it
+   
 span

--- a/test/autotest/whitespace-only-reset-indent/input.htmljs
+++ b/test/autotest/whitespace-only-reset-indent/input.htmljs
@@ -1,0 +1,3 @@
+div
+     
+span


### PR DESCRIPTION
reset indent on new-line (to fix whitespace body issue).

fix for 
https://github.com/marko-js/htmljs-parser/issues/63