### PR TITLE
Fix parsing comments inside of scriptlets

### DIFF
--- a/Parser.js
+++ b/Parser.js
@@ -2886,7 +2886,7 @@ class Parser extends BaseParser {
 
             eol(str) {
                 parser.rewind(str.length);
-                currentPart.endPos = parser.pos - str.length;
+                currentPart.endPos = parser.pos;
                 endJavaScriptComment();
             },
 
@@ -3060,8 +3060,8 @@ class Parser extends BaseParser {
                 if (currentPart.endMatch || currentPart.stringType === CODE_BACKTICK) {
                     currentPart.value += str;
                 } else {
-                    endInlineScript(parser.pos - str.length);
                     parser.rewind(str.length);
+                    endInlineScript(parser.pos);
                 }
             },
 

--- a/Parser.js
+++ b/Parser.js
@@ -3080,6 +3080,12 @@ class Parser extends BaseParser {
             },
 
             char(ch, code) {
+                if (code === CODE_BACK_SLASH) {
+                    currentPart.value += ch + parser.lookAtCharAhead(1);
+                    parser.skip(1);
+                    return;
+                }
+
                 if (code === CODE_FORWARD_SLASH) {
                     // Check next character to see if we are in a comment
                     var nextCode = parser.lookAtCharCodeAhead(1);
@@ -3095,12 +3101,6 @@ class Parser extends BaseParser {
                }
 
                 currentPart.value += ch;
-
-                if (code === CODE_BACK_SLASH) {
-                    currentPart.value += parser.lookAtCharAhead(1);
-                    parser.skip(1);
-                    return;
-                }
 
                 if (currentPart.stringType) {
                     if (code === currentPart.stringType) {

--- a/Parser.js
+++ b/Parser.js
@@ -828,7 +828,7 @@ class Parser extends BaseParser {
             return;
         }
 
-        function handleTrailingWhitespaceMultilineHtmlBlcok(err, eof) {
+        function handleTrailingWhitespaceMultilineHtmlBlock(err, eof) {
             if (err) {
                 // This is a non-whitespace! We don't allow non-whitespace
                 // after matching two or more hyphens. This is user error...
@@ -1174,7 +1174,7 @@ class Parser extends BaseParser {
 
                 parser.enterState(STATE_CONCISE_HTML_CONTENT);
 
-                beginCheckTrailingWhitespace(handleTrailingWhitespaceMultilineHtmlBlcok);
+                beginCheckTrailingWhitespace(handleTrailingWhitespaceMultilineHtmlBlock);
                 return;
             } else if (parser.lookAheadFor(htmlBlockIndent, parser.pos + newLine.length)) {
                 // We know the next line does not end the multiline HTML block, but we need to check if there
@@ -1595,20 +1595,6 @@ class Parser extends BaseParser {
                         return;
                     } else if (parser.lookAtCharCodeAhead(1) === CODE_PERCENT) {
                         beginScriptlet();
-                        parser.skip(1);
-                        return;
-                    }
-                }
-
-
-                if (code === CODE_FORWARD_SLASH) {
-                    if (parser.lookAtCharCodeAhead(1) === CODE_ASTERISK) {
-                        // Skip over code inside a JavaScript block comment
-                        beginBlockComment();
-                        parser.skip(1);
-                        return;
-                    } else if (parser.lookAtCharCodeAhead(1) === CODE_FORWARD_SLASH) {
-                        beginLineComment();
                         parser.skip(1);
                         return;
                     }
@@ -2878,8 +2864,6 @@ class Parser extends BaseParser {
             },
 
             char(ch, code) {
-
-
                 if (code === CODE_ASTERISK) {
                     var nextCode = parser.lookAtCharCodeAhead(1);
                     if (nextCode === CODE_FORWARD_SLASH) {
@@ -2901,9 +2885,8 @@ class Parser extends BaseParser {
             name: 'STATE_JS_COMMENT_LINE',
 
             eol(str) {
-                currentPart.value += str;
-                currentPart.endPos = parser.pos;
-                currentPart.eol = str;
+                parser.rewind(str.length);
+                currentPart.endPos = parser.pos - str.length;
                 endJavaScriptComment();
             },
 
@@ -3077,7 +3060,7 @@ class Parser extends BaseParser {
                 if (currentPart.endMatch || currentPart.stringType === CODE_BACKTICK) {
                     currentPart.value += str;
                 } else {
-                    endInlineScript(parser.pos);
+                    endInlineScript(parser.pos - str.length);
                     parser.rewind(str.length);
                 }
             },
@@ -3097,6 +3080,20 @@ class Parser extends BaseParser {
             },
 
             char(ch, code) {
+                if (code === CODE_FORWARD_SLASH) {
+                    // Check next character to see if we are in a comment
+                    var nextCode = parser.lookAtCharCodeAhead(1);
+                    if (nextCode === CODE_FORWARD_SLASH) {
+                        beginLineComment();
+                        parser.skip(1);
+                        return;
+                    } else if (nextCode === CODE_ASTERISK) {
+                        beginBlockComment();
+                        parser.skip(1);
+                        return;
+                    }
+               }
+
                 currentPart.value += ch;
 
                 if (code === CODE_BACK_SLASH) {
@@ -3115,20 +3112,6 @@ class Parser extends BaseParser {
                 if (code === currentPart.endMatch) {
                     currentPart.endMatch = currentPart.endMatches.pop();
                     return;
-                }
-
-                if (code === CODE_FORWARD_SLASH) {
-                     // Check next character to see if we are in a comment
-                     var nextCode = parser.lookAtCharCodeAhead(1);
-                     if (nextCode === CODE_FORWARD_SLASH) {
-                         beginLineComment();
-                         parser.skip(1);
-                         return;
-                     } else if (nextCode === CODE_ASTERISK) {
-                         beginBlockComment();
-                         parser.skip(1);
-                         return;
-                     }
                 }
 
                 if (code === CODE_SINGLE_QUOTE || code === CODE_DOUBLE_QUOTE || code === CODE_BACKTICK) {

--- a/test/autotest-1.x/comment-concise-js-line/expected.html
+++ b/test/autotest-1.x/comment-concise-js-line/expected.html
@@ -1,4 +1,4 @@
 <div>
     comment:"This is a single line comment"
-    text:"This is the body of the div tag"
+    text:"\nThis is the body of the div tag"
 </div>

--- a/test/autotest/comment-concise-js-line/expected.html
+++ b/test/autotest/comment-concise-js-line/expected.html
@@ -1,4 +1,4 @@
 <div>
     comment:"This is a single line comment"
-    text:"This is the body of the div tag"
+    text:"\nThis is the body of the div tag"
 </div>

--- a/test/autotest/scriptlet-block-multiline-comment/expected.html
+++ b/test/autotest/scriptlet-block-multiline-comment/expected.html
@@ -1,1 +1,1 @@
-scriptlet(block):"\n    //* foo */\n    var foo = 123;\n"
+scriptlet(block):"\n    /* foo */\n    var foo = 123;\n"

--- a/test/autotest/scriptlet-block-single-line-comment/expected.html
+++ b/test/autotest/scriptlet-block-single-line-comment/expected.html
@@ -1,1 +1,1 @@
-scriptlet(block):"\n    /// foo\n    var foo = 123;\n"
+scriptlet(block):"\n    // foo\n    var foo = 123;\n"

--- a/test/autotest/scriptlet-line-multiline-comments/expected.html
+++ b/test/autotest/scriptlet-line-multiline-comments/expected.html
@@ -1,0 +1,5 @@
+scriptlet(line):"var str /* test */ = '' /**\n* Test\n*/"
+text:"\n\n"
+<div>
+    text:"\n  Hello\n"
+</div>

--- a/test/autotest/scriptlet-line-multiline-comments/input.htmljs
+++ b/test/autotest/scriptlet-line-multiline-comments/input.htmljs
@@ -1,0 +1,7 @@
+$ var str /* test */ = '' /**
+* Test
+*/
+
+<div>
+  Hello
+</div>

--- a/test/autotest/scriptlet-line-trailing-line-comment/expected.html
+++ b/test/autotest/scriptlet-line-trailing-line-comment/expected.html
@@ -1,0 +1,5 @@
+scriptlet(line):"var str = '' // a string"
+text:"\n\n"
+<div>
+    text:"\n  Hello\n"
+</div>

--- a/test/autotest/scriptlet-line-trailing-line-comment/input.htmljs
+++ b/test/autotest/scriptlet-line-trailing-line-comment/input.htmljs
@@ -1,0 +1,5 @@
+$ var str = '' // a string
+
+<div>
+  Hello
+</div>

--- a/test/autotest/text-after-semicolon/expected.html
+++ b/test/autotest/text-after-semicolon/expected.html
@@ -1,7 +1,7 @@
 <span>
     comment:"Hello World"
 </span>
-text:"\n"
+text:"\n\n"
 <span>
     comment:"Hello World"
 </span>


### PR DESCRIPTION
Fixes two issues with parsing comments inside scriptlets.

1. Previously an inline script with a trailing single line comment would consume the following two lines because both the inline script and the comment were looking for the end of the line.

This is fixed by making the inline script parsing not include the trailing newline as part of the script.

2. Comments inside inline scripts had an additional `/` which caused multiline comments to not work properly.

This is fixed by not adding the character in a script when we detect we are going into a comment.
