### PR TITLE
Fix false positive for regexp parsing in css values

### DIFF
--- a/Parser.js
+++ b/Parser.js
@@ -2228,7 +2228,7 @@ class Parser extends BaseParser {
                             parser.enterState(STATE_WITHIN_OPEN_TAG);
                         }
                         return;
-                    } else if (!/[\]})A-Z0-9.<]/i.test(getPreviousNonWhitespaceChar())) {
+                    } else if (!/[\]})A-Z0-9.<%]/i.test(getPreviousNonWhitespaceChar())) {
                         beginRegularExpression();
                         return;
                     } 

--- a/test/autotest/css-calc/expected.html
+++ b/test/autotest/css-calc/expected.html
@@ -1,0 +1,6 @@
+<style {
+    .example {
+        margin-left: calc((-100% / 12 - 200px) / 2);
+    }
+}=(EMPTY)>
+</style>

--- a/test/autotest/css-calc/input.htmljs
+++ b/test/autotest/css-calc/input.htmljs
@@ -1,0 +1,5 @@
+﻿style {
+    .example {
+        margin-left: calc((-100% / 12 - 200px) / 2);
+    }
+}


### PR DESCRIPTION
Currently the parser can get tripped up and enter the regexp parsing mode when it discovers `% /` which is valid inside of css calculated values.

This PR adds `%` to the list of invalid characters before a regexp. Technically this would break JS like

```
x % /some-reg/
```

However people are probably not likely running mod against a regexp.