### PR TITLE
fix: tag var with default attribute properly parsed

### DIFF
--- a/test/autotest/tag-var-declaration/expected.html
+++ b/test/autotest/tag-var-declaration/expected.html
@@ -6,10 +6,10 @@ text:"\n"
 <let/(foo) SELF_CLOSED>
 </let>
 text:"\n"
-<let/(foo) =1 SELF_CLOSED>
+<let/(foo)=1 SELF_CLOSED>
 </let>
 text:"\n"
-<let/(foo) =1 SELF_CLOSED>
+<let/(foo)=1 SELF_CLOSED>
 </let>
 text:"\n"
 <let/(foo + 1) SELF_CLOSED>


### PR DESCRIPTION
Fixes an issue where a tag variable followed by a default attribute was being parsed as a normal attribute without a name instead of having the `default: true` property set.