### PR TITLE
fix: support closing tag variations on text parse modes

### DIFF
--- a/Parser.js
+++ b/Parser.js
@@ -1082,15 +1082,19 @@ class Parser extends BaseParser {
         function checkForClosingTag() {
             // Look ahead to see if we found the closing tag that will
             // take us out of the EXPRESSION state...
-            var lookAhead = '/' + expectedCloseTagName + '>';
-            var match = parser.lookAheadFor(lookAhead);
+            var match = (
+                parser.lookAheadFor('/>') ||
+                parser.lookAheadFor('/' + peek(blockStack).tagName + '>') ||
+                parser.lookAheadFor('/' + expectedCloseTagName + '>')
+            );
+
             if (match) {
                 if (parser.state === STATE_JS_COMMENT_LINE) {
                     endJavaScriptComment();
                 }
                 endText();
 
-                closeTag(expectedCloseTagName, parser.pos, parser.pos + 1 + lookAhead.length);
+                closeTag(expectedCloseTagName, parser.pos, parser.pos + 1 + match.length);
                 parser.skip(match.length);
                 parser.enterState(STATE_HTML_CONTENT);
                 return true;

--- a/test/autotest-1.x/parsed-text-style-tag-class/expected.html
+++ b/test/autotest-1.x/parsed-text-style-tag-class/expected.html
@@ -1,0 +1,12 @@
+<style shorthandClassNames=["test"]>
+    text:"content"
+</style>
+text:"\n"
+<style shorthandClassNames=["test"]>
+    text:"content"
+</style>
+text:"\n"
+<style shorthandClassNames=["test"]>
+    text:"content"
+</style>
+text:"\n"

--- a/test/autotest-1.x/parsed-text-style-tag-class/input.htmljs
+++ b/test/autotest-1.x/parsed-text-style-tag-class/input.htmljs
@@ -1,0 +1,3 @@
+<style.test>content</>
+<style.test>content</style>
+<style.test>content</style.test>


### PR DESCRIPTION
This PR supports tags parsed in either `static-text` or `parsed-content` mode (such as `<script>` and `<style>`) having a closing tag that matches the same variants as other tags.

Specifically this means the below is newly supported:

```
<style.test></>
<style.test></style>
```

Where as before only `<style.test></style.test>` would have been valid.