### PR TITLE
fix: support parenthesis within tag var expression

### DIFF
--- a/Parser.js
+++ b/Parser.js
@@ -2519,7 +2519,7 @@ class Parser extends BaseParser {
                             parser.rewind(1);
                             parser.enterState(STATE_WITHIN_OPEN_TAG);
                             return;
-                        } else if (parser.lookAtCharCodeAhead(1) === CODE_OPEN_PAREN) {
+                        } else if (parser.lookAtCharCodeAhead(1) === CODE_OPEN_PAREN && currentPart.value) {
                             currentPart.value += ch;
                             endExpression();
                             parser.enterState(STATE_TAG_ARGS);


### PR DESCRIPTION
For the most part the htmljs-parser supports arbitrary js expressions for all places where a JS expression is allowed. Currently with tag variables, a parenthesis expression cannot be used, eg: `<tag/(x)/>` would error.

This PR supports this, without breaking arguments following a tag var (`<tag/x(y)/>`) which will cause the error to be reported in the Marko compiler itself.