### PR TITLE
feat: add shorthand method attributes

### DIFF
--- a/notify-util.js
+++ b/notify-util.js
@@ -137,7 +137,8 @@ exports.createNotifiers = function(parser, listeners) {
                         value: attr.value,
                         pos: attr.pos,
                         endPos: attr.endPos,
-                        argument: attr.argument
+                        argument: attr.argument,
+                        method: attr.method,
                     };
 
                     if (attr.hasOwnProperty('literalValue')) {

--- a/test/autotest/attr-method-shorthand/expected.html
+++ b/test/autotest/attr-method-shorthand/expected.html
@@ -1,0 +1,26 @@
+<foo onclick=function(event) { 
+  console.log("hello"); 
+  event.preventDefault();
+} SELF_CLOSED>
+</foo>
+text:"\n"
+text:"\n"
+<foo onclick=function(event) { 
+  console.log("hello"); 
+  event.preventDefault();
+} SELF_CLOSED>
+</foo>
+text:"\n"
+text:"\n"
+<foo DEFAULT=function(event) { 
+  console.log("hello"); 
+  event.preventDefault();
+} SELF_CLOSED>
+</foo>
+text:"\n"
+text:"\n"
+<foo DEFAULT=function(event) { 
+  console.log("hello"); 
+  event.preventDefault();
+} SELF_CLOSED>
+</foo>

--- a/test/autotest/attr-method-shorthand/input.htmljs
+++ b/test/autotest/attr-method-shorthand/input.htmljs
@@ -1,0 +1,19 @@
+<foo onclick(event) { 
+  console.log("hello"); 
+  event.preventDefault();
+}/>
+
+<foo onclick (event) { 
+  console.log("hello"); 
+  event.preventDefault();
+}/>
+
+<foo(event) { 
+  console.log("hello"); 
+  event.preventDefault();
+}/>
+
+<foo (event) { 
+  console.log("hello"); 
+  event.preventDefault();
+}/>


### PR DESCRIPTION
Adds support for parsing shorthand methods as attributes: 
```marko
<foo onclick(event) { 
  console.log("hello"); 
  event.preventDefault();
}/>

<foo(event) { 
  console.log("hello"); 
  event.preventDefault();
}/>
```