### PR TITLE
fix: issues with releasing from main branch

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -48,7 +48,7 @@ jobs:
     needs: [lint, test]
     steps:
       - name: Check releasable
-        if: ${{ github.repository == 'marko-js/htmljs-parser' && github.ref == 'refs/heads/next' && github.event_name == 'push' }}
+        if: ${{ github.repository == 'marko-js/htmljs-parser' && github.event_name == 'push' && (github.ref == 'refs/heads/main' || github.ref == 'refs/heads/next') }}
         run: exit 0
       - name: Checkout code
         uses: actions/checkout@v2

--- a/.releaserc.json
+++ b/.releaserc.json
@@ -1,0 +1,3 @@
+{
+  "branches": ["main", "next"]
+}


### PR DESCRIPTION
## Description

After merging in the new parser API changes it wasn't setup so that the `main` branch could be released from (only `next`).
This PR fixes that.

## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->

<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [ ] I have updated/added documentation affected by my changes.
- [ ] I have added tests to cover my changes.

<!--
Disclaimer: Contributions via GitHub pull requests are gladly accepted from their original author. Along with any pull requests, please state that the contribution is your original work and that you license the work to the project under the project's open source license. Whether or not you state this explicitly, by submitting any copyrighted material via pull request, email, or other means you agree to license the material under the project's open source license and warrant that you have the legal authority to do so.
-->
