### PR TITLE
chore: allow CI to commit formatted files

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -14,6 +14,8 @@ jobs:
     steps:
       - name: Checkout code
         uses: actions/checkout@v3
+        with:
+          ref: ${{ github.head_ref }}
       - name: Use node
         uses: actions/setup-node@v2
         with:


### PR DESCRIPTION
## Description

Fixes an issue where the CI format action was not able to commit formatted files back.

## Checklist:

- [ ] I have updated/added documentation affected by my changes.
- [ ] I have added tests to cover my changes.

