### PR TITLE
fix: issue with expression continuations containing equals

### DIFF
--- a/.changeset/strong-buckets-attack.md
+++ b/.changeset/strong-buckets-attack.md
@@ -1,0 +1,5 @@
+---
+"htmljs-parser": patch
+---
+
+Fix expression continuations containing equals not consuming enough characters

--- a/src/__tests__/fixtures/attr-operators-space-before/__snapshots__/attr-operators-space-before.expected.txt
+++ b/src/__tests__/fixtures/attr-operators-space-before/__snapshots__/attr-operators-space-before.expected.txt
@@ -493,10 +493,10 @@
   │   │╰─ attrName
   ╰─  ╰─ tagName
 66╭─ <a=x >=y a/>
-  │   │││ │╰─ text "=y a/>\n"
-  │   │││ ╰─ openTagEnd
-  │   ││╰─ attrValue.value
-  │   │├─ attrValue "=x"
+  │   │││     │╰─ openTagEnd:selfClosed "/>"
+  │   │││     ╰─ attrName
+  │   ││╰─ attrValue.value "x >=y"
+  │   │├─ attrValue "=x >=y"
   │   │╰─ attrName
   ╰─  ╰─ tagName
 67╭─ <a=x &=y a/>
@@ -507,125 +507,110 @@
   │   │╰─ attrName
   ╰─  ╰─ tagName
 68╭─ <a=x &&=y a/>
-  │  ││││      │╰─ openTagEnd:selfClosed "/>"
-  │  ││││      ╰─ attrName
-  │  │││╰─ attrValue.value "x &&=y"
-  │  ││├─ attrValue "=x &&=y"
-  │  ││╰─ attrName
-  │  │╰─ tagName
-  ╰─ ╰─ text "\n"
+  │   │││      │╰─ openTagEnd:selfClosed "/>"
+  │   │││      ╰─ attrName
+  │   ││╰─ attrValue.value "x &&=y"
+  │   │├─ attrValue "=x &&=y"
+  │   │╰─ attrName
+  ╰─  ╰─ tagName
 69╭─ <a=x |=y a/>
-  │  ││││     │╰─ openTagEnd:selfClosed "/>"
-  │  ││││     ╰─ attrName
-  │  │││╰─ attrValue.value "x |=y"
-  │  ││├─ attrValue "=x |=y"
-  │  ││╰─ attrName
-  │  │╰─ tagName
-  ╰─ ╰─ text "\n"
+  │   │││     │╰─ openTagEnd:selfClosed "/>"
+  │   │││     ╰─ attrName
+  │   ││╰─ attrValue.value "x |=y"
+  │   │├─ attrValue "=x |=y"
+  │   │╰─ attrName
+  ╰─  ╰─ tagName
 70╭─ <a=x ||=y a/>
-  │  ││││      │╰─ openTagEnd:selfClosed "/>"
-  │  ││││      ╰─ attrName
-  │  │││╰─ attrValue.value "x ||=y"
-  │  ││├─ attrValue "=x ||=y"
-  │  ││╰─ attrName
-  │  │╰─ tagName
-  ╰─ ╰─ text "\n"
+  │   │││      │╰─ openTagEnd:selfClosed "/>"
+  │   │││      ╰─ attrName
+  │   ││╰─ attrValue.value "x ||=y"
+  │   │├─ attrValue "=x ||=y"
+  │   │╰─ attrName
+  ╰─  ╰─ tagName
 71╭─ <a=x ^=y a/>
-  │  ││││     │╰─ openTagEnd:selfClosed "/>"
-  │  ││││     ╰─ attrName
-  │  │││╰─ attrValue.value "x ^=y"
-  │  ││├─ attrValue "=x ^=y"
-  │  ││╰─ attrName
-  │  │╰─ tagName
-  ╰─ ╰─ text "\n"
+  │   │││     │╰─ openTagEnd:selfClosed "/>"
+  │   │││     ╰─ attrName
+  │   ││╰─ attrValue.value "x ^=y"
+  │   │├─ attrValue "=x ^=y"
+  │   │╰─ attrName
+  ╰─  ╰─ tagName
 72╭─ <a=x ~=y a/>
-  │  ││││     │╰─ openTagEnd:selfClosed "/>"
-  │  ││││     ╰─ attrName
-  │  │││╰─ attrValue.value "x ~=y"
-  │  ││├─ attrValue "=x ~=y"
-  │  ││╰─ attrName
-  │  │╰─ tagName
-  ╰─ ╰─ text "\n"
+  │   │││     │╰─ openTagEnd:selfClosed "/>"
+  │   │││     ╰─ attrName
+  │   ││╰─ attrValue.value "x ~=y"
+  │   │├─ attrValue "=x ~=y"
+  │   │╰─ attrName
+  ╰─  ╰─ tagName
 73╭─ <a=x >>=y a/>
-  │  ││││      │╰─ openTagEnd:selfClosed "/>"
-  │  ││││      ╰─ attrName
-  │  │││╰─ attrValue.value "x >>=y"
-  │  ││├─ attrValue "=x >>=y"
-  │  ││╰─ attrName
-  │  │╰─ tagName
-  ╰─ ╰─ text "\n"
+  │   │││      │╰─ openTagEnd:selfClosed "/>"
+  │   │││      ╰─ attrName
+  │   ││╰─ attrValue.value "x >>=y"
+  │   │├─ attrValue "=x >>=y"
+  │   │╰─ attrName
+  ╰─  ╰─ tagName
 74╭─ <a=x >>>=y a/>
-  │  ││││       │╰─ openTagEnd:selfClosed "/>"
-  │  ││││       ╰─ attrName
-  │  │││╰─ attrValue.value "x >>>=y"
-  │  ││├─ attrValue "=x >>>=y"
-  │  ││╰─ attrName
-  │  │╰─ tagName
-  ╰─ ╰─ text "\n"
+  │   │││       │╰─ openTagEnd:selfClosed "/>"
+  │   │││       ╰─ attrName
+  │   ││╰─ attrValue.value "x >>>=y"
+  │   │├─ attrValue "=x >>>=y"
+  │   │╰─ attrName
+  ╰─  ╰─ tagName
 75╭─ <a=x -=y a/>
-  │  ││││     │╰─ openTagEnd:selfClosed "/>"
-  │  ││││     ╰─ attrName
-  │  │││╰─ attrValue.value "x -=y"
-  │  ││├─ attrValue "=x -=y"
-  │  ││╰─ attrName
-  │  │╰─ tagName
-  ╰─ ╰─ text "\n"
+  │   │││     │╰─ openTagEnd:selfClosed "/>"
+  │   │││     ╰─ attrName
+  │   ││╰─ attrValue.value "x -=y"
+  │   │├─ attrValue "=x -=y"
+  │   │╰─ attrName
+  ╰─  ╰─ tagName
 76╭─ <a=x /=y a/>
-  │  ││││     │╰─ openTagEnd:selfClosed "/>"
-  │  ││││     ╰─ attrName
-  │  │││╰─ attrValue.value "x /=y"
-  │  ││├─ attrValue "=x /=y"
-  │  ││╰─ attrName
-  │  │╰─ tagName
-  ╰─ ╰─ text "\n"
+  │   │││     │╰─ openTagEnd:selfClosed "/>"
+  │   │││     ╰─ attrName
+  │   ││╰─ attrValue.value "x /=y"
+  │   │├─ attrValue "=x /=y"
+  │   │╰─ attrName
+  ╰─  ╰─ tagName
 77╭─ <a=x *=y a/>
-  │  ││││     │╰─ openTagEnd:selfClosed "/>"
-  │  ││││     ╰─ attrName
-  │  │││╰─ attrValue.value "x *=y"
-  │  ││├─ attrValue "=x *=y"
-  │  ││╰─ attrName
-  │  │╰─ tagName
-  ╰─ ╰─ text "\n"
+  │   │││     │╰─ openTagEnd:selfClosed "/>"
+  │   │││     ╰─ attrName
+  │   ││╰─ attrValue.value "x *=y"
+  │   │├─ attrValue "=x *=y"
+  │   │╰─ attrName
+  ╰─  ╰─ tagName
 78╭─ <a=x **=y a/>
-  │  ││││      │╰─ openTagEnd:selfClosed "/>"
-  │  ││││      ╰─ attrName
-  │  │││╰─ attrValue.value "x **=y"
-  │  ││├─ attrValue "=x **=y"
-  │  ││╰─ attrName
-  │  │╰─ tagName
-  ╰─ ╰─ text "\n"
+  │   │││      │╰─ openTagEnd:selfClosed "/>"
+  │   │││      ╰─ attrName
+  │   ││╰─ attrValue.value "x **=y"
+  │   │├─ attrValue "=x **=y"
+  │   │╰─ attrName
+  ╰─  ╰─ tagName
 79╭─ <a=x %=y a/>
-  │  ││││     │╰─ openTagEnd:selfClosed "/>"
-  │  ││││     ╰─ attrName
-  │  │││╰─ attrValue.value "x %=y"
-  │  ││├─ attrValue "=x %=y"
-  │  ││╰─ attrName
-  │  │╰─ tagName
-  ╰─ ╰─ text "\n"
+  │   │││     │╰─ openTagEnd:selfClosed "/>"
+  │   │││     ╰─ attrName
+  │   ││╰─ attrValue.value "x %=y"
+  │   │├─ attrValue "=x %=y"
+  │   │╰─ attrName
+  ╰─  ╰─ tagName
 80╭─ <a=x +=y a/>
-  │  ││││     │╰─ openTagEnd:selfClosed "/>"
-  │  ││││     ╰─ attrName
-  │  │││╰─ attrValue.value "x +=y"
-  │  ││├─ attrValue "=x +=y"
-  │  ││╰─ attrName
-  │  │╰─ tagName
-  ╰─ ╰─ text "\n"
+  │   │││     │╰─ openTagEnd:selfClosed "/>"
+  │   │││     ╰─ attrName
+  │   ││╰─ attrValue.value "x +=y"
+  │   │├─ attrValue "=x +=y"
+  │   │╰─ attrName
+  ╰─  ╰─ tagName
 81╭─ <a=x++ +y a/>
-  │  ││││      │╰─ openTagEnd:selfClosed "/>"
-  │  ││││      ╰─ attrName
-  │  │││╰─ attrValue.value "x++ +y"
-  │  ││├─ attrValue "=x++ +y"
-  │  ││╰─ attrName
-  │  │╰─ tagName
-  ╰─ ╰─ text "\n"
+  │   │││      │╰─ openTagEnd:selfClosed "/>"
+  │   │││      ╰─ attrName
+  │   ││╰─ attrValue.value "x++ +y"
+  │   │├─ attrValue "=x++ +y"
+  │   │╰─ attrName
+  ╰─  ╰─ tagName
 82╭─ <a=x+ ++y a/>
-  │  ││││      │╰─ openTagEnd:selfClosed "/>"
-  │  ││││      ╰─ attrName
-  │  │││╰─ attrValue.value "x+ ++y"
-  │  ││├─ attrValue "=x+ ++y"
-  │  ││╰─ attrName
-  │  │╰─ tagName
-  ╰─ ╰─ text "\n"
+  │   │││      │╰─ openTagEnd:selfClosed "/>"
+  │   │││      ╰─ attrName
+  │   ││╰─ attrValue.value "x+ ++y"
+  │   │├─ attrValue "=x+ ++y"
+  │   │╰─ attrName
+  ╰─  ╰─ tagName
 83╭─ <a=x >y <a/>
   │  ││││ ││  │╰─ openTagEnd:selfClosed "/>"
   │  ││││ ││  ╰─ tagName
@@ -635,7 +620,7 @@
   │  ││├─ attrValue "=x"
   │  ││╰─ attrName
   │  │╰─ tagName
-  ╰─ ╰─ text "\n"
+  ╰─ ╰─ error(MISSING_END_TAG:Missing ending "a" tag) "<a=x >"
 84╭─ <a=x >>y a/>
   │  ││││     │╰─ openTagEnd:selfClosed "/>"
   │  ││││     ╰─ attrName
@@ -669,34 +654,36 @@
   │  │╰─ tagName
   ╰─ ╰─ text "\n"
 88╭─ <a=x =>y a/>
-  │  ││││  │╰─ text "y a/>\n"
-  │  ││││  ╰─ openTagEnd
-  │  │││╰─ attrValue.value "x ="
-  │  ││├─ attrValue "=x ="
+  │  ││││     │╰─ openTagEnd:selfClosed "/>"
+  │  ││││     ╰─ attrName
+  │  │││╰─ attrValue.value "x =>y"
+  │  ││├─ attrValue "=x =>y"
   │  ││╰─ attrName
   │  │╰─ tagName
   ╰─ ╰─ text "\n"
 89╭─ <a=x => (y ) a/>
-  │   │││  │╰─ text " (y ) a/>\n"
-  │   │││  ╰─ openTagEnd
-  │   ││╰─ attrValue.value "x ="
-  │   │├─ attrValue "=x ="
-  │   │╰─ attrName
-  ╰─  ╰─ tagName
-90╭─ <a=x => {y } a/>
-  │  ││││  │╰─ text " {y } a/>\n"
-  │  ││││  ╰─ openTagEnd
-  │  │││╰─ attrValue.value "x ="
-  │  ││├─ attrValue "=x ="
+  │  ││││         │╰─ openTagEnd:selfClosed "/>"
+  │  ││││         ╰─ attrName
+  │  │││╰─ attrValue.value "x => (y )"
+  │  ││├─ attrValue "=x => (y )"
   │  ││╰─ attrName
   │  │╰─ tagName
-  ╰─ ╰─ error(MISSING_END_TAG:Missing ending "a" tag) "<a=x =>"
+  ╰─ ╰─ text "\n"
+90╭─ <a=x => {y } a/>
+  │  ││││         │╰─ openTagEnd:selfClosed "/>"
+  │  ││││         ╰─ attrName
+  │  │││╰─ attrValue.value "x => {y }"
+  │  ││├─ attrValue "=x => {y }"
+  │  ││╰─ attrName
+  │  │╰─ tagName
+  ╰─ ╰─ text "\n"
 91╭─ <a=( x ) {y } a/>
-  │   │││          │╰─ openTagEnd:selfClosed "/>"
-  │   │││          ╰─ attrName
-  │   ││╰─ attrValue.value "( x ) {y }"
-  │   │├─ attrValue "=( x ) {y }"
-  │   │╰─ attrName
-  ╰─  ╰─ tagName
+  │  ││││          │╰─ openTagEnd:selfClosed "/>"
+  │  ││││          ╰─ attrName
+  │  │││╰─ attrValue.value "( x ) {y }"
+  │  ││├─ attrValue "=( x ) {y }"
+  │  ││╰─ attrName
+  │  │╰─ tagName
+  ╰─ ╰─ text "\n"
 92╭─ 
   ╰─ ╰─ text "\n"

--- a/src/__tests__/fixtures/attr-operators-space-between/__snapshots__/attr-operators-space-between.expected.txt
+++ b/src/__tests__/fixtures/attr-operators-space-between/__snapshots__/attr-operators-space-between.expected.txt
@@ -677,10 +677,10 @@
   │   │╰─ attrName
   ╰─  ╰─ tagName
 89╭─ <a=x >= y a/>
-  │   │││ │╰─ text "= y a/>\n"
-  │   │││ ╰─ openTagEnd
-  │   ││╰─ attrValue.value
-  │   │├─ attrValue "=x"
+  │   │││      │╰─ openTagEnd:selfClosed "/>"
+  │   │││      ╰─ attrName
+  │   ││╰─ attrValue.value "x >= y"
+  │   │├─ attrValue "=x >= y"
   │   │╰─ attrName
   ╰─  ╰─ tagName
 90╭─ <a=x &= y a/>
@@ -691,178 +691,157 @@
   │   │╰─ attrName
   ╰─  ╰─ tagName
 91╭─ <a=x &&= y a/>
-  │  ││││       │╰─ openTagEnd:selfClosed "/>"
-  │  ││││       ╰─ attrName
-  │  │││╰─ attrValue.value "x &&= y"
-  │  ││├─ attrValue "=x &&= y"
-  │  ││╰─ attrName
-  │  │╰─ tagName
-  ╰─ ╰─ text "\n"
+  │   │││       │╰─ openTagEnd:selfClosed "/>"
+  │   │││       ╰─ attrName
+  │   ││╰─ attrValue.value "x &&= y"
+  │   │├─ attrValue "=x &&= y"
+  │   │╰─ attrName
+  ╰─  ╰─ tagName
 92╭─ <a=x |= y a/>
-  │  ││││      │╰─ openTagEnd:selfClosed "/>"
-  │  ││││      ╰─ attrName
-  │  │││╰─ attrValue.value "x |= y"
-  │  ││├─ attrValue "=x |= y"
-  │  ││╰─ attrName
-  │  │╰─ tagName
-  ╰─ ╰─ text "\n"
+  │   │││      │╰─ openTagEnd:selfClosed "/>"
+  │   │││      ╰─ attrName
+  │   ││╰─ attrValue.value "x |= y"
+  │   │├─ attrValue "=x |= y"
+  │   │╰─ attrName
+  ╰─  ╰─ tagName
 93╭─ <a=x ||= y a/>
-  │  ││││       │╰─ openTagEnd:selfClosed "/>"
-  │  ││││       ╰─ attrName
-  │  │││╰─ attrValue.value "x ||= y"
-  │  ││├─ attrValue "=x ||= y"
-  │  ││╰─ attrName
-  │  │╰─ tagName
-  ╰─ ╰─ text "\n"
+  │   │││       │╰─ openTagEnd:selfClosed "/>"
+  │   │││       ╰─ attrName
+  │   ││╰─ attrValue.value "x ||= y"
+  │   │├─ attrValue "=x ||= y"
+  │   │╰─ attrName
+  ╰─  ╰─ tagName
 94╭─ <a=x ^= y a/>
-  │  ││││      │╰─ openTagEnd:selfClosed "/>"
-  │  ││││      ╰─ attrName
-  │  │││╰─ attrValue.value "x ^= y"
-  │  ││├─ attrValue "=x ^= y"
-  │  ││╰─ attrName
-  │  │╰─ tagName
-  ╰─ ╰─ text "\n"
+  │   │││      │╰─ openTagEnd:selfClosed "/>"
+  │   │││      ╰─ attrName
+  │   ││╰─ attrValue.value "x ^= y"
+  │   │├─ attrValue "=x ^= y"
+  │   │╰─ attrName
+  ╰─  ╰─ tagName
 95╭─ <a=x ~= y a/>
-  │  ││││      │╰─ openTagEnd:selfClosed "/>"
-  │  ││││      ╰─ attrName
-  │  │││╰─ attrValue.value "x ~= y"
-  │  ││├─ attrValue "=x ~= y"
-  │  ││╰─ attrName
-  │  │╰─ tagName
-  ╰─ ╰─ text "\n"
+  │   │││      │╰─ openTagEnd:selfClosed "/>"
+  │   │││      ╰─ attrName
+  │   ││╰─ attrValue.value "x ~= y"
+  │   │├─ attrValue "=x ~= y"
+  │   │╰─ attrName
+  ╰─  ╰─ tagName
 96╭─ <a=x >>= y a/>
-  │  ││││       │╰─ openTagEnd:selfClosed "/>"
-  │  ││││       ╰─ attrName
-  │  │││╰─ attrValue.value "x >>= y"
-  │  ││├─ attrValue "=x >>= y"
-  │  ││╰─ attrName
-  │  │╰─ tagName
-  ╰─ ╰─ text "\n"
+  │   │││       │╰─ openTagEnd:selfClosed "/>"
+  │   │││       ╰─ attrName
+  │   ││╰─ attrValue.value "x >>= y"
+  │   │├─ attrValue "=x >>= y"
+  │   │╰─ attrName
+  ╰─  ╰─ tagName
 97╭─ <a=x >>>= y a/>
-  │  ││││        │╰─ openTagEnd:selfClosed "/>"
-  │  ││││        ╰─ attrName
-  │  │││╰─ attrValue.value "x >>>= y"
-  │  ││├─ attrValue "=x >>>= y"
-  │  ││╰─ attrName
-  │  │╰─ tagName
-  ╰─ ╰─ text "\n"
+  │   │││        │╰─ openTagEnd:selfClosed "/>"
+  │   │││        ╰─ attrName
+  │   ││╰─ attrValue.value "x >>>= y"
+  │   │├─ attrValue "=x >>>= y"
+  │   │╰─ attrName
+  ╰─  ╰─ tagName
 98╭─ <a=x -= y a/>
-  │  ││││      │╰─ openTagEnd:selfClosed "/>"
-  │  ││││      ╰─ attrName
-  │  │││╰─ attrValue.value "x -= y"
-  │  ││├─ attrValue "=x -= y"
-  │  ││╰─ attrName
-  │  │╰─ tagName
-  ╰─ ╰─ text "\n"
+  │   │││      │╰─ openTagEnd:selfClosed "/>"
+  │   │││      ╰─ attrName
+  │   ││╰─ attrValue.value "x -= y"
+  │   │├─ attrValue "=x -= y"
+  │   │╰─ attrName
+  ╰─  ╰─ tagName
 99╭─ <a=x /= y a/>
-  │  ││││      │╰─ openTagEnd:selfClosed "/>"
-  │  ││││      ╰─ attrName
-  │  │││╰─ attrValue.value "x /= y"
-  │  ││├─ attrValue "=x /= y"
-  │  ││╰─ attrName
-  │  │╰─ tagName
-  ╰─ ╰─ text "\n"
+  │   │││      │╰─ openTagEnd:selfClosed "/>"
+  │   │││      ╰─ attrName
+  │   ││╰─ attrValue.value "x /= y"
+  │   │├─ attrValue "=x /= y"
+  │   │╰─ attrName
+  ╰─  ╰─ tagName
 100╭─ <a=x *= y a/>
-   │  ││││      │╰─ openTagEnd:selfClosed "/>"
-   │  ││││      ╰─ attrName
-   │  │││╰─ attrValue.value "x *= y"
-   │  ││├─ attrValue "=x *= y"
-   │  ││╰─ attrName
-   │  │╰─ tagName
-   ╰─ ╰─ text "\n"
+   │   │││      │╰─ openTagEnd:selfClosed "/>"
+   │   │││      ╰─ attrName
+   │   ││╰─ attrValue.value "x *= y"
+   │   │├─ attrValue "=x *= y"
+   │   │╰─ attrName
+   ╰─  ╰─ tagName
 101╭─ <a=x **= y a/>
-   │  ││││       │╰─ openTagEnd:selfClosed "/>"
-   │  ││││       ╰─ attrName
-   │  │││╰─ attrValue.value "x **= y"
-   │  ││├─ attrValue "=x **= y"
-   │  ││╰─ attrName
-   │  │╰─ tagName
-   ╰─ ╰─ text "\n"
+   │   │││       │╰─ openTagEnd:selfClosed "/>"
+   │   │││       ╰─ attrName
+   │   ││╰─ attrValue.value "x **= y"
+   │   │├─ attrValue "=x **= y"
+   │   │╰─ attrName
+   ╰─  ╰─ tagName
 102╭─ <a=x %= y a/>
-   │  ││││      │╰─ openTagEnd:selfClosed "/>"
-   │  ││││      ╰─ attrName
-   │  │││╰─ attrValue.value "x %= y"
-   │  ││├─ attrValue "=x %= y"
-   │  ││╰─ attrName
-   │  │╰─ tagName
-   ╰─ ╰─ text "\n"
+   │   │││      │╰─ openTagEnd:selfClosed "/>"
+   │   │││      ╰─ attrName
+   │   ││╰─ attrValue.value "x %= y"
+   │   │├─ attrValue "=x %= y"
+   │   │╰─ attrName
+   ╰─  ╰─ tagName
 103╭─ <a=x += y a/>
-   │  ││││      │╰─ openTagEnd:selfClosed "/>"
-   │  ││││      ╰─ attrName
-   │  │││╰─ attrValue.value "x += y"
-   │  ││├─ attrValue "=x += y"
-   │  ││╰─ attrName
-   │  │╰─ tagName
-   ╰─ ╰─ text "\n"
+   │   │││      │╰─ openTagEnd:selfClosed "/>"
+   │   │││      ╰─ attrName
+   │   ││╰─ attrValue.value "x += y"
+   │   │├─ attrValue "=x += y"
+   │   │╰─ attrName
+   ╰─  ╰─ tagName
 104╭─ <a=x in;/>
-   │  ││││ │  ╰─ openTagEnd:selfClosed "/>"
-   │  ││││ ╰─ attrName "in;"
-   │  │││╰─ attrValue.value
-   │  ││├─ attrValue "=x"
-   │  ││╰─ attrName
-   │  │╰─ tagName
-   ╰─ ╰─ text "\n"
+   │   │││ │  ╰─ openTagEnd:selfClosed "/>"
+   │   │││ ╰─ attrName "in;"
+   │   ││╰─ attrValue.value
+   │   │├─ attrValue "=x"
+   │   │╰─ attrName
+   ╰─  ╰─ tagName
 105╭─ <a=x in y a/>
-   │  ││││      │╰─ openTagEnd:selfClosed "/>"
-   │  ││││      ╰─ attrName
-   │  │││╰─ attrValue.value "x in y"
-   │  ││├─ attrValue "=x in y"
-   │  ││╰─ attrName
-   │  │╰─ tagName
-   ╰─ ╰─ text "\n"
+   │   │││      │╰─ openTagEnd:selfClosed "/>"
+   │   │││      ╰─ attrName
+   │   ││╰─ attrValue.value "x in y"
+   │   │├─ attrValue "=x in y"
+   │   │╰─ attrName
+   ╰─  ╰─ tagName
 106╭─ <a=x in=y/>
-   │  ││││ │ ││╰─ openTagEnd:selfClosed "/>"
-   │  ││││ │ │╰─ attrValue.value
-   │  ││││ │ ╰─ attrValue "=y"
-   │  ││││ ╰─ attrName "in"
-   │  │││╰─ attrValue.value
-   │  ││├─ attrValue "=x"
-   │  ││╰─ attrName
-   │  │╰─ tagName
-   ╰─ ╰─ text "\n"
+   │   │││ │ ││╰─ openTagEnd:selfClosed "/>"
+   │   │││ │ │╰─ attrValue.value
+   │   │││ │ ╰─ attrValue "=y"
+   │   │││ ╰─ attrName "in"
+   │   ││╰─ attrValue.value
+   │   │├─ attrValue "=x"
+   │   │╰─ attrName
+   ╰─  ╰─ tagName
 107╭─ <a=x in, y/>
-   │  ││││ │   │╰─ openTagEnd:selfClosed "/>"
-   │  ││││ │   ╰─ attrName
-   │  ││││ ╰─ attrName "in"
-   │  │││╰─ attrValue.value
-   │  ││├─ attrValue "=x"
-   │  ││╰─ attrName
-   │  │╰─ tagName
-   ╰─ ╰─ text "\n"
+   │   │││ │   │╰─ openTagEnd:selfClosed "/>"
+   │   │││ │   ╰─ attrName
+   │   │││ ╰─ attrName "in"
+   │   ││╰─ attrValue.value
+   │   │├─ attrValue "=x"
+   │   │╰─ attrName
+   ╰─  ╰─ tagName
 108╭─ <a=x instanceof y a/>
-   │  ││││              │╰─ openTagEnd:selfClosed "/>"
-   │  ││││              ╰─ attrName
-   │  │││╰─ attrValue.value "x instanceof y"
-   │  ││├─ attrValue "=x instanceof y"
-   │  ││╰─ attrName
-   │  │╰─ tagName
-   ╰─ ╰─ text "\n"
+   │   │││              │╰─ openTagEnd:selfClosed "/>"
+   │   │││              ╰─ attrName
+   │   ││╰─ attrValue.value "x instanceof y"
+   │   │├─ attrValue "=x instanceof y"
+   │   │╰─ attrName
+   ╰─  ╰─ tagName
 109╭─ <a=x ++ + y a/>
-   │  ││││        │╰─ openTagEnd:selfClosed "/>"
-   │  ││││        ╰─ attrName
-   │  │││╰─ attrValue.value "x ++ + y"
-   │  ││├─ attrValue "=x ++ + y"
-   │  ││╰─ attrName
-   │  │╰─ tagName
-   ╰─ ╰─ text "\n"
+   │   │││        │╰─ openTagEnd:selfClosed "/>"
+   │   │││        ╰─ attrName
+   │   ││╰─ attrValue.value "x ++ + y"
+   │   │├─ attrValue "=x ++ + y"
+   │   │╰─ attrName
+   ╰─  ╰─ tagName
 110╭─ <a=x + ++ y a/>
-   │  ││││        │╰─ openTagEnd:selfClosed "/>"
-   │  ││││        ╰─ attrName
-   │  │││╰─ attrValue.value "x + ++ y"
-   │  ││├─ attrValue "=x + ++ y"
-   │  ││╰─ attrName
-   │  │╰─ tagName
-   ╰─ ╰─ text "\n"
+   │   │││        │╰─ openTagEnd:selfClosed "/>"
+   │   │││        ╰─ attrName
+   │   ││╰─ attrValue.value "x + ++ y"
+   │   │├─ attrValue "=x + ++ y"
+   │   │╰─ attrName
+   ╰─  ╰─ tagName
 111╭─ <a=x ++ y a/>
-   │  ││││ │  │ │╰─ openTagEnd:selfClosed "/>"
-   │  ││││ │  │ ╰─ attrName
-   │  ││││ │  ╰─ attrName
-   │  ││││ ╰─ attrName "++"
-   │  │││╰─ attrValue.value
-   │  ││├─ attrValue "=x"
-   │  ││╰─ attrName
-   │  │╰─ tagName
-   ╰─ ╰─ text "\n"
+   │   │││ │  │ │╰─ openTagEnd:selfClosed "/>"
+   │   │││ │  │ ╰─ attrName
+   │   │││ │  ╰─ attrName
+   │   │││ ╰─ attrName "++"
+   │   ││╰─ attrValue.value
+   │   │├─ attrValue "=x"
+   │   │╰─ attrName
+   ╰─  ╰─ tagName
 112╭─ <a=x > y <a/>
    │  ││││ ││   │╰─ openTagEnd:selfClosed "/>"
    │  ││││ ││   ╰─ tagName
@@ -872,7 +851,7 @@
    │  ││├─ attrValue "=x"
    │  ││╰─ attrName
    │  │╰─ tagName
-   ╰─ ╰─ text "\n"
+   ╰─ ╰─ error(MISSING_END_TAG:Missing ending "a" tag) "<a=x >"
 113╭─ <a=x >> y a/>
    │  ││││      │╰─ openTagEnd:selfClosed "/>"
    │  ││││      ╰─ attrName
@@ -906,69 +885,74 @@
    │  │╰─ tagName
    ╰─ ╰─ text "\n"
 117╭─ <a=x => y a/>
-   │  ││││  │╰─ text " y a/>\n"
-   │  ││││  ╰─ openTagEnd
-   │  │││╰─ attrValue.value "x ="
-   │  ││├─ attrValue "=x ="
+   │  ││││      │╰─ openTagEnd:selfClosed "/>"
+   │  ││││      ╰─ attrName
+   │  │││╰─ attrValue.value "x => y"
+   │  ││├─ attrValue "=x => y"
    │  ││╰─ attrName
    │  │╰─ tagName
    ╰─ ╰─ text "\n"
 118╭─ <a=x => ( y ) a/>
-   │   │││  │╰─ text " ( y ) a/>\n"
-   │   │││  ╰─ openTagEnd
-   │   ││╰─ attrValue.value "x ="
-   │   │├─ attrValue "=x ="
-   │   │╰─ attrName
-   ╰─  ╰─ tagName
+   │  ││││          │╰─ openTagEnd:selfClosed "/>"
+   │  ││││          ╰─ attrName
+   │  │││╰─ attrValue.value "x => ( y )"
+   │  ││├─ attrValue "=x => ( y )"
+   │  ││╰─ attrName
+   │  │╰─ tagName
+   ╰─ ╰─ text "\n"
 119╭─ <a=x => { y } a/>
-   │   │││  │╰─ text " { y } a/>\n"
-   │   │││  ╰─ openTagEnd
-   │   ││╰─ attrValue.value "x ="
-   │   │├─ attrValue "=x ="
-   │   │╰─ attrName
-   ╰─  ╰─ tagName
+   │  ││││          │╰─ openTagEnd:selfClosed "/>"
+   │  ││││          ╰─ attrName
+   │  │││╰─ attrValue.value "x => { y }"
+   │  ││├─ attrValue "=x => { y }"
+   │  ││╰─ attrName
+   │  │╰─ tagName
+   ╰─ ╰─ text "\n"
 120╭─ <a=( x ) { y } a/>
-   │   │││           │╰─ openTagEnd:selfClosed "/>"
-   │   │││           ╰─ attrName
-   │   ││╰─ attrValue.value "( x ) { y }"
-   │   │├─ attrValue "=( x ) { y }"
-   │   │╰─ attrName
-   ╰─  ╰─ tagName
+   │  ││││           │╰─ openTagEnd:selfClosed "/>"
+   │  ││││           ╰─ attrName
+   │  │││╰─ attrValue.value "( x ) { y }"
+   │  ││├─ attrValue "=( x ) { y }"
+   │  ││╰─ attrName
+   │  │╰─ tagName
+   ╰─ ╰─ text "\n"
 121╭─ <a= (x) => { console.log("y") } a/>
-   │  │││ │    │╰─ text " { console.log(\"y\") } a/>\n"
-   │  │││ │    ╰─ openTagEnd
-   │  │││ ╰─ attrValue.value "(x) ="
-   │  ││├─ attrValue "= (x) ="
+   │  │││ │                           │╰─ openTagEnd:selfClosed "/>"
+   │  │││ │                           ╰─ attrName
+   │  │││ ╰─ attrValue.value "(x) => { console.log(\"y\") }"
+   │  ││├─ attrValue "= (x) => { console.log(\"y\") }"
    │  ││╰─ attrName
    │  │╰─ tagName
    ╰─ ╰─ text "\n"
 122╭─ <a= async x => { console.log("y") } a/>
-   │   ││ │        │╰─ text " { console.log(\"y\") } a/>\n"
-   │   ││ │        ╰─ openTagEnd
-   │   ││ ╰─ attrValue.value "async x ="
-   │   │├─ attrValue "= async x ="
-   │   │╰─ attrName
-   ╰─  ╰─ tagName
-123╭─ <a= function (x) { console.log("y") } a/>
-   │   ││ │                                 │╰─ openTagEnd:selfClosed "/>"
-   │   ││ │                                 ╰─ attrName
-   │   ││ ╰─ attrValue.value "function (x) { console.log(\"y\") }"
-   │   │├─ attrValue "= function (x) { console.log(\"y\") }"
-   │   │╰─ attrName
-   ╰─  ╰─ tagName
-124╭─ <a= x => { console.log("y") } a/>
-   │  │││ │  │╰─ text " { console.log(\"y\") } a/>\n"
-   │  │││ │  ╰─ openTagEnd
-   │  │││ ╰─ attrValue.value "x ="
-   │  ││├─ attrValue "= x ="
+   │  │││ │                               │╰─ openTagEnd:selfClosed "/>"
+   │  │││ │                               ╰─ attrName
+   │  │││ ╰─ attrValue.value "async x => { console.log(\"y\") }"
+   │  ││├─ attrValue "= async x => { console.log(\"y\") }"
    │  ││╰─ attrName
    │  │╰─ tagName
-   │  ├─ text "\n"
-   ╰─ ╰─ error(MISSING_END_TAG:Missing ending "a" tag) "<a= x =>"
+   ╰─ ╰─ text "\n"
+123╭─ <a= function (x) { console.log("y") } a/>
+   │  │││ │                                 │╰─ openTagEnd:selfClosed "/>"
+   │  │││ │                                 ╰─ attrName
+   │  │││ ╰─ attrValue.value "function (x) { console.log(\"y\") }"
+   │  ││├─ attrValue "= function (x) { console.log(\"y\") }"
+   │  ││╰─ attrName
+   │  │╰─ tagName
+   ╰─ ╰─ text "\n"
+124╭─ <a= x => { console.log("y") } a/>
+   │  │││ │                         │╰─ openTagEnd:selfClosed "/>"
+   │  │││ │                         ╰─ attrName
+   │  │││ ╰─ attrValue.value "x => { console.log(\"y\") }"
+   │  ││├─ attrValue "= x => { console.log(\"y\") }"
+   │  ││╰─ attrName
+   │  │╰─ tagName
+   ╰─ ╰─ text "\n"
 125╭─ <a= async function (x) { console.log("y") } a/>
-   │   ││ │                                       │╰─ openTagEnd:selfClosed "/>"
-   │   ││ │                                       ╰─ attrName
-   │   ││ ╰─ attrValue.value "async function (x) { console.log(\"y\") }"
-   │   │├─ attrValue "= async function (x) { console.log(\"y\") }"
-   │   │╰─ attrName
-   ╰─  ╰─ tagName
+   │  │││ │                                       │╰─ openTagEnd:selfClosed "/>"
+   │  │││ │                                       ╰─ attrName
+   │  │││ ╰─ attrValue.value "async function (x) { console.log(\"y\") }"
+   │  ││├─ attrValue "= async function (x) { console.log(\"y\") }"
+   │  ││╰─ attrName
+   │  │╰─ tagName
+   ╰─ ╰─ text "\n"

--- a/src/states/EXPRESSION.ts
+++ b/src/states/EXPRESSION.ts
@@ -203,8 +203,8 @@ export const EXPRESSION: StateDefinition<ExpressionMeta> = {
 
 function buildOperatorPattern(isConcise: boolean) {
   const binary =
-    "[!~*%&^|?:<]+" + // Any of these characters can always continue an expression
-    "|(?<=[!=<>&^~|/*?%+-])=|=(?=[!=<>&^~|/*?%+-])" + // Match equality and multi char assignment operators w/o matching equals by itself
+    "(?:[!~*%&^|?:<]+=*)+" + // Any of these characters can always continue an expression
+    "|[>/+-=]+=|=>" + // Match equality and multi char assignment operators w/o matching equals by itself
     "|(?<!\\+)[ \\t]*\\+(?:[ \\t]*\\+[ \\t]*\\+)*[ \\t]*(?!\\+)" + // We only match an odd number of plus's
     `|(?<!-)-${isConcise ? "" : "(?:[ \\t]*-[ \\t]*-)*[ \\t]*"}(?!-)` + // In concise mode we can't match multiple hyphens otherwise we can match an even number of hyphens
     `|(?<![/*])/(?![/*${isConcise ? "" : ">"}])` + // We only continue after a forward slash if it isn't //, /* (or /> in html mode)


### PR DESCRIPTION
## Description

Fixes a bug where expression continuations containing equals (eg `!=`) were not consuming enough text because of unnecessary look ahead/behind.

Also optimize and limits valid equals sign expression regexes.
## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->

<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [ ] I have updated/added documentation affected by my changes.
- [ ] I have added tests to cover my changes.

<!--
Disclaimer: Contributions via GitHub pull requests are gladly accepted from their original author. Along with any pull requests, please state that the contribution is your original work and that you license the work to the project under the project's open source license. Whether or not you state this explicitly, by submitting any copyrighted material via pull request, email, or other means you agree to license the material under the project's open source license and warrant that you have the legal authority to do so.
-->
