### PR TITLE
fix: bracket mismatch issue

### DIFF
--- a/.changeset/tidy-moles-train.md
+++ b/.changeset/tidy-moles-train.md
@@ -1,0 +1,5 @@
+---
+"htmljs-parser": patch
+---
+
+Fix issue where parser would sometimes not consume enough characters and cause a bracket mismatch

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "htmljs-parser",
-  "version": "3.3.0",
+  "version": "3.3.4",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "htmljs-parser",
-      "version": "3.3.0",
+      "version": "3.3.4",
       "license": "MIT",
       "devDependencies": {
         "@changesets/changelog-github": "^0.4.4",

--- a/src/__tests__/fixtures/attr-method-shorthand/__snapshots__/attr-method-shorthand.expected.txt
+++ b/src/__tests__/fixtures/attr-method-shorthand/__snapshots__/attr-method-shorthand.expected.txt
@@ -1,4 +1,27 @@
-1╭─ <foo onclick(event) { 
+1╭─ <foo onclick(event){}/>
+ │   │   │      ││     ││╰─ openTagEnd:selfClosed "/>"
+ │   │   │      ││     │╰─ attrMethod.body.value
+ │   │   │      ││     ╰─ attrMethod.body "{}"
+ │   │   │      │╰─ attrMethod.params.value "event"
+ │   │   │      ├─ attrMethod.params "(event)"
+ │   │   │      ╰─ attrMethod "(event){}"
+ │   │   ╰─ attrName "onclick"
+ ╰─  ╰─ tagName "foo"
+2├─ 
+3╭─ <foo onclick(event){ 
+ │   │   │      ││     │╰─ attrMethod.body.value " \n  console.log(\"hello\"); \n  event.preventDefault();\n"
+ │   │   │      ││     ╰─ attrMethod.body "{ \n  console.log(\"hello\"); \n  event.preventDefault();\n}"
+ │   │   │      │╰─ attrMethod.params.value "event"
+ │   │   │      ├─ attrMethod.params "(event)"
+ │   │   │      ╰─ attrMethod "(event){ \n  console.log(\"hello\"); \n  event.preventDefault();\n}"
+ │   │   ╰─ attrName "onclick"
+ ╰─  ╰─ tagName "foo"
+4├─   console.log("hello"); 
+5├─   event.preventDefault();
+6╭─ }/>
+ ╰─  ╰─ openTagEnd:selfClosed "/>"
+7├─ 
+8╭─ <foo onclick(event) { 
  │   │   │      ││      │╰─ attrMethod.body.value " \n  console.log(\"hello\"); \n  event.preventDefault();\n"
  │   │   │      ││      ╰─ attrMethod.body "{ \n  console.log(\"hello\"); \n  event.preventDefault();\n}"
  │   │   │      │╰─ attrMethod.params.value "event"
@@ -6,25 +29,38 @@
  │   │   │      ╰─ attrMethod "(event) { \n  console.log(\"hello\"); \n  event.preventDefault();\n}"
  │   │   ╰─ attrName "onclick"
  ╰─  ╰─ tagName "foo"
-2├─   console.log("hello"); 
-3├─   event.preventDefault();
-4╭─ }/>
- ╰─  ╰─ openTagEnd:selfClosed "/>"
-5├─ 
-6╭─ <foo onclick (event) { 
- │   │   │       ││      │╰─ attrMethod.body.value " \n  console.log(\"hello\"); \n  event.preventDefault();\n"
- │   │   │       ││      ╰─ attrMethod.body "{ \n  console.log(\"hello\"); \n  event.preventDefault();\n}"
- │   │   │       │╰─ attrMethod.params.value "event"
- │   │   │       ├─ attrMethod.params "(event)"
- │   │   │       ╰─ attrMethod "(event) { \n  console.log(\"hello\"); \n  event.preventDefault();\n}"
- │   │   ╰─ attrName "onclick"
- ╰─  ╰─ tagName "foo"
-7├─   console.log("hello"); 
-8├─   event.preventDefault();
-9╭─ }/>
- ╰─  ╰─ openTagEnd:selfClosed "/>"
-10├─ 
-11╭─ <foo(event) { 
+9├─   console.log("hello"); 
+10├─   event.preventDefault();
+11╭─ }/>
+  ╰─  ╰─ openTagEnd:selfClosed "/>"
+12├─ 
+13╭─ <foo onclick (event) { 
+  │   │   │       ││      │╰─ attrMethod.body.value " \n  console.log(\"hello\"); \n  event.preventDefault();\n"
+  │   │   │       ││      ╰─ attrMethod.body "{ \n  console.log(\"hello\"); \n  event.preventDefault();\n}"
+  │   │   │       │╰─ attrMethod.params.value "event"
+  │   │   │       ├─ attrMethod.params "(event)"
+  │   │   │       ╰─ attrMethod "(event) { \n  console.log(\"hello\"); \n  event.preventDefault();\n}"
+  │   │   ╰─ attrName "onclick"
+  ╰─  ╰─ tagName "foo"
+14├─   console.log("hello"); 
+15├─   event.preventDefault();
+16╭─ }/>
+  ╰─  ╰─ openTagEnd:selfClosed "/>"
+17├─ 
+18╭─ <foo(event){ 
+  │   │  ││     │╰─ attrMethod.body.value " \n  console.log(\"hello\"); \n  event.preventDefault();\n"
+  │   │  ││     ╰─ attrMethod.body "{ \n  console.log(\"hello\"); \n  event.preventDefault();\n}"
+  │   │  │╰─ attrMethod.params.value "event"
+  │   │  ├─ attrMethod.params "(event)"
+  │   │  ├─ attrMethod "(event){ \n  console.log(\"hello\"); \n  event.preventDefault();\n}"
+  │   │  ╰─ attrName
+  ╰─  ╰─ tagName "foo"
+19├─   console.log("hello"); 
+20├─   event.preventDefault();
+21╭─ }/>
+  ╰─  ╰─ openTagEnd:selfClosed "/>"
+22├─ 
+23╭─ <foo(event) { 
   │   │  ││      │╰─ attrMethod.body.value " \n  console.log(\"hello\"); \n  event.preventDefault();\n"
   │   │  ││      ╰─ attrMethod.body "{ \n  console.log(\"hello\"); \n  event.preventDefault();\n}"
   │   │  │╰─ attrMethod.params.value "event"
@@ -32,12 +68,12 @@
   │   │  ├─ attrMethod "(event) { \n  console.log(\"hello\"); \n  event.preventDefault();\n}"
   │   │  ╰─ attrName
   ╰─  ╰─ tagName "foo"
-12├─   console.log("hello"); 
-13├─   event.preventDefault();
-14╭─ }/>
+24├─   console.log("hello"); 
+25├─   event.preventDefault();
+26╭─ }/>
   ╰─  ╰─ openTagEnd:selfClosed "/>"
-15├─ 
-16╭─ <foo (event) { 
+27├─ 
+28╭─ <foo (event) { 
   │   │   ││      │╰─ attrMethod.body.value " \n  console.log(\"hello\"); \n  event.preventDefault();\n"
   │   │   ││      ╰─ attrMethod.body "{ \n  console.log(\"hello\"); \n  event.preventDefault();\n}"
   │   │   │╰─ attrMethod.params.value "event"
@@ -45,25 +81,39 @@
   │   │   ├─ attrMethod "(event) { \n  console.log(\"hello\"); \n  event.preventDefault();\n}"
   │   │   ╰─ attrName
   ╰─  ╰─ tagName "foo"
-17├─   console.log("hello"); 
-18├─   event.preventDefault();
-19╭─ }/>
+29├─   console.log("hello"); 
+30├─   event.preventDefault();
+31╭─ }/>
   ╰─  ╰─ openTagEnd:selfClosed "/>"
-20├─ 
-21╭─ foo onclick(event) { 
+32├─ 
+33╭─ foo onclick(event){ 
+  │  │   │      ││     │╰─ attrMethod.body.value " \n  console.log(\"hello\"); \n  event.preventDefault();\n"
+  │  │   │      ││     ╰─ attrMethod.body "{ \n  console.log(\"hello\"); \n  event.preventDefault();\n}"
+  │  │   │      │╰─ attrMethod.params.value "event"
+  │  │   │      ├─ attrMethod.params "(event)"
+  │  │   │      ╰─ attrMethod "(event){ \n  console.log(\"hello\"); \n  event.preventDefault();\n}"
+  │  │   ╰─ attrName "onclick"
+  ╰─ ╰─ tagName "foo"
+34├─   console.log("hello"); 
+35├─   event.preventDefault();
+36├─ }
+37╭─ 
+  ╰─ ╰─ openTagEnd
+38╭─ foo onclick(event) { 
   │  │   │      ││      │╰─ attrMethod.body.value " \n  console.log(\"hello\"); \n  event.preventDefault();\n"
   │  │   │      ││      ╰─ attrMethod.body "{ \n  console.log(\"hello\"); \n  event.preventDefault();\n}"
   │  │   │      │╰─ attrMethod.params.value "event"
   │  │   │      ├─ attrMethod.params "(event)"
   │  │   │      ╰─ attrMethod "(event) { \n  console.log(\"hello\"); \n  event.preventDefault();\n}"
   │  │   ╰─ attrName "onclick"
+  │  ├─ closeTag(foo)
   ╰─ ╰─ tagName "foo"
-22├─   console.log("hello"); 
-23├─   event.preventDefault();
-24├─ }
-25╭─ 
+39├─   console.log("hello"); 
+40├─   event.preventDefault();
+41├─ }
+42╭─ 
   ╰─ ╰─ openTagEnd
-26╭─ foo onclick (event) { 
+43╭─ foo onclick (event) { 
   │  │   │       ││      │╰─ attrMethod.body.value " \n  console.log(\"hello\"); \n  event.preventDefault();\n"
   │  │   │       ││      ╰─ attrMethod.body "{ \n  console.log(\"hello\"); \n  event.preventDefault();\n}"
   │  │   │       │╰─ attrMethod.params.value "event"
@@ -72,12 +122,26 @@
   │  │   ╰─ attrName "onclick"
   │  ├─ closeTag(foo)
   ╰─ ╰─ tagName "foo"
-27├─   console.log("hello"); 
-28├─   event.preventDefault();
-29├─ }
-30╭─ 
+44├─   console.log("hello"); 
+45├─   event.preventDefault();
+46├─ }
+47╭─ 
   ╰─ ╰─ openTagEnd
-31╭─ foo(event) { 
+48╭─ foo(event){ 
+  │  │  ││     │╰─ attrMethod.body.value " \n  console.log(\"hello\"); \n  event.preventDefault();\n"
+  │  │  ││     ╰─ attrMethod.body "{ \n  console.log(\"hello\"); \n  event.preventDefault();\n}"
+  │  │  │╰─ attrMethod.params.value "event"
+  │  │  ├─ attrMethod.params "(event)"
+  │  │  ├─ attrMethod "(event){ \n  console.log(\"hello\"); \n  event.preventDefault();\n}"
+  │  │  ╰─ attrName
+  │  ├─ closeTag(foo)
+  ╰─ ╰─ tagName "foo"
+49├─   console.log("hello"); 
+50├─   event.preventDefault();
+51├─ }
+52╭─ 
+  ╰─ ╰─ openTagEnd
+53╭─ foo(event) { 
   │  │  ││      │╰─ attrMethod.body.value " \n  console.log(\"hello\"); \n  event.preventDefault();\n"
   │  │  ││      ╰─ attrMethod.body "{ \n  console.log(\"hello\"); \n  event.preventDefault();\n}"
   │  │  │╰─ attrMethod.params.value "event"
@@ -86,12 +150,12 @@
   │  │  ╰─ attrName
   │  ├─ closeTag(foo)
   ╰─ ╰─ tagName "foo"
-32├─   console.log("hello"); 
-33├─   event.preventDefault();
-34├─ }
-35╭─ 
+54├─   console.log("hello"); 
+55├─   event.preventDefault();
+56├─ }
+57╭─ 
   ╰─ ╰─ openTagEnd
-36╭─ foo (event) { 
+58╭─ foo (event) { 
   │  │   ││      │╰─ attrMethod.body.value " \n  console.log(\"hello\"); \n  event.preventDefault();\n"
   │  │   ││      ╰─ attrMethod.body "{ \n  console.log(\"hello\"); \n  event.preventDefault();\n}"
   │  │   │╰─ attrMethod.params.value "event"
@@ -100,8 +164,8 @@
   │  │   ╰─ attrName
   │  ├─ closeTag(foo)
   ╰─ ╰─ tagName "foo"
-37├─   console.log("hello"); 
-38├─   event.preventDefault();
-39╭─ }
+59├─   console.log("hello"); 
+60├─   event.preventDefault();
+61╭─ }
   │   ├─ closeTag(foo)
   ╰─  ╰─ openTagEnd

--- a/src/__tests__/fixtures/attr-method-shorthand/input.marko
+++ b/src/__tests__/fixtures/attr-method-shorthand/input.marko
@@ -1,9 +1,21 @@
+<foo onclick(event){}/>
+
+<foo onclick(event){ 
+  console.log("hello"); 
+  event.preventDefault();
+}/>
+
 <foo onclick(event) { 
   console.log("hello"); 
   event.preventDefault();
 }/>
 
 <foo onclick (event) { 
+  console.log("hello"); 
+  event.preventDefault();
+}/>
+
+<foo(event){ 
   console.log("hello"); 
   event.preventDefault();
 }/>
@@ -18,12 +30,22 @@
   event.preventDefault();
 }/>
 
+foo onclick(event){ 
+  console.log("hello"); 
+  event.preventDefault();
+}
+
 foo onclick(event) { 
   console.log("hello"); 
   event.preventDefault();
 }
 
 foo onclick (event) { 
+  console.log("hello"); 
+  event.preventDefault();
+}
+
+foo(event){ 
   console.log("hello"); 
   event.preventDefault();
 }

--- a/src/__tests__/fixtures/testing/__snapshots__/testing.expected.txt
+++ b/src/__tests__/fixtures/testing/__snapshots__/testing.expected.txt
@@ -1,7 +1,0 @@
-1╭─ <div.hello-${world}-again/>
- │   │  ││     │       │     ╰─ openTagEnd:selfClosed "/>"
- │   │  ││     │       ╰─ tagShorthandClass.quasis[1] "-again"
- │   │  ││     ╰─ tagShorthandClass.expressions[0] "${world}"
- │   │  │╰─ tagShorthandClass.quasis[0] "hello-"
- │   │  ╰─ tagShorthandClass ".hello-${world}-again"
- ╰─  ╰─ tagName "div"

--- a/src/__tests__/fixtures/testing/input.marko
+++ b/src/__tests__/fixtures/testing/input.marko
@@ -1,1 +1,0 @@
-<div.hello-${world}-again/>

--- a/src/states/ATTRIBUTE.ts
+++ b/src/states/ATTRIBUTE.ts
@@ -90,6 +90,7 @@ export const ATTRIBUTE: StateDefinition<AttrMeta> = {
       (code === CODE.PERIOD && this.lookAheadFor(".."))
     ) {
       attr.valueStart = this.pos;
+      this.forward = 0;
 
       if (code === CODE.COLON) {
         ensureAttrName(this, attr);
@@ -111,31 +112,29 @@ export const ATTRIBUTE: StateDefinition<AttrMeta> = {
       expr.terminator = this.isConcise
         ? CONCISE_VALUE_TERMINATORS
         : HTML_VALUE_TERMINATORS;
-
-      this.pos--;
     } else if (code === CODE.OPEN_PAREN) {
       ensureAttrName(this, attr);
       attr.stage = ATTR_STAGE.ARGUMENT;
       this.pos++; // skip (
+      this.forward = 0;
       this.enterState(STATE.EXPRESSION).terminator = CODE.CLOSE_PAREN;
-      this.pos--;
     } else if (code === CODE.OPEN_CURLY_BRACE && attr.args) {
       ensureAttrName(this, attr);
       attr.stage = ATTR_STAGE.BLOCK;
       this.pos++; // skip {
+      this.forward = 0;
       const expr = this.enterState(STATE.EXPRESSION);
       expr.terminatedByWhitespace = false;
       expr.terminator = CODE.CLOSE_CURLY_BRACE;
-      this.pos--;
     } else if (attr.stage === ATTR_STAGE.UNKNOWN) {
       attr.stage = ATTR_STAGE.NAME;
+      this.forward = 0;
       const expr = this.enterState(STATE.EXPRESSION);
       expr.terminatedByWhitespace = true;
       expr.skipOperators = true;
       expr.terminator = this.isConcise
         ? CONCISE_NAME_TERMINATORS
         : HTML_NAME_TERMINATORS;
-      this.pos--;
     } else {
       this.exitState();
     }

--- a/src/states/BEGIN_DELIMITED_HTML_BLOCK.ts
+++ b/src/states/BEGIN_DELIMITED_HTML_BLOCK.ts
@@ -39,8 +39,8 @@ export const BEGIN_DELIMITED_HTML_BLOCK: StateDefinition<DelimitedHTMLBlockMeta>
         const startPos = this.pos;
         if (!this.consumeWhitespaceOnLine()) {
           this.pos = startPos + 1;
+          this.forward = 0;
           this.beginHtmlBlock(undefined, true);
-          this.pos--;
         }
       }
     },

--- a/src/states/CONCISE_HTML_CONTENT.ts
+++ b/src/states/CONCISE_HTML_CONTENT.ts
@@ -119,7 +119,7 @@ export const CONCISE_HTML_CONTENT: StateDefinition = {
       }
 
       this.enterState(STATE.OPEN_TAG);
-      this.pos--; // START_TAG_NAME expects to start at the first character
+      this.forward = 0; // START_TAG_NAME expects to start at the first character
     }
   },
 

--- a/src/states/INLINE_SCRIPT.ts
+++ b/src/states/INLINE_SCRIPT.ts
@@ -38,17 +38,17 @@ export const INLINE_SCRIPT: StateDefinition<ScriptletMeta> = {
   eof() {},
 
   char(code, inlineScript) {
+    this.forward = 0;
+
     if (code === CODE.OPEN_CURLY_BRACE) {
       inlineScript.block = true;
       this.pos++; // skip {
       const expr = this.enterState(STATE.EXPRESSION);
       expr.terminator = CODE.CLOSE_CURLY_BRACE;
       expr.skipOperators = true;
-      this.pos--;
     } else {
       const expr = this.enterState(STATE.EXPRESSION);
       expr.terminatedByEOL = true;
-      this.pos--;
     }
   },
 

--- a/src/states/OPEN_TAG.ts
+++ b/src/states/OPEN_TAG.ts
@@ -287,11 +287,12 @@ export const OPEN_TAG: StateDefinition<OpenTagMeta> = {
       // ignore whitespace within element...
     } else if (code === CODE.COMMA) {
       this.pos++; // skip ,
+      this.forward = 0;
       this.consumeWhitespace();
-      this.pos--;
     } else if (code === CODE.FORWARD_SLASH && !tag.hasAttrs) {
       tag.stage = TAG_STAGE.VAR;
       this.pos++; // skip /
+      this.forward = 0;
 
       if (isWhitespaceCode(this.lookAtCharCodeAhead(0))) {
         return this.emitError(
@@ -306,7 +307,6 @@ export const OPEN_TAG: StateDefinition<OpenTagMeta> = {
       expr.terminator = this.isConcise
         ? CONCISE_TAG_VAR_TERMINATORS
         : HTML_TAG_VAR_TERMINATORS;
-      this.pos--;
     } else if (code === CODE.OPEN_PAREN && !tag.hasAttrs) {
       if (tag.hasArgs) {
         this.emitError(
@@ -318,26 +318,26 @@ export const OPEN_TAG: StateDefinition<OpenTagMeta> = {
       }
       tag.stage = TAG_STAGE.ARGUMENT;
       this.pos++; // skip (
+      this.forward = 0;
       const expr = this.enterState(STATE.EXPRESSION);
       expr.skipOperators = true;
       expr.terminator = CODE.CLOSE_PAREN;
-      this.pos--;
     } else if (code === CODE.PIPE && !tag.hasAttrs) {
       tag.stage = TAG_STAGE.PARAMS;
       this.pos++; // skip |
+      this.forward = 0;
       const expr = this.enterState(STATE.EXPRESSION);
       expr.skipOperators = true;
       expr.terminator = CODE.PIPE;
-      this.pos--;
     } else {
+      this.forward = 0;
+
       if (tag.tagName) {
         this.enterState(STATE.ATTRIBUTE);
         tag.hasAttrs = true;
       } else {
         this.enterState(STATE.TAG_NAME);
       }
-
-      this.pos--;
     }
   },
 
@@ -381,7 +381,7 @@ export const OPEN_TAG: StateDefinition<OpenTagMeta> = {
               attr.start = start;
               attr.args = { start, end, value };
               tag.hasAttrs = true;
-              this.pos--;
+              this.forward = 0;
             } else {
               tag.hasArgs = true;
               this.options.onTagArgs?.({

--- a/src/states/PLACEHOLDER.ts
+++ b/src/states/PLACEHOLDER.ts
@@ -93,8 +93,8 @@ export function checkForPlaceholder(parser: Parser, code: number) {
       parser.endText();
       parser.enterState(PLACEHOLDER).escape = escape;
       parser.pos += escape ? 2 : 3; // skip ${ or $!{
+      parser.forward = 0;
       parser.enterState(STATE.EXPRESSION).terminator = CODE.CLOSE_CURLY_BRACE;
-      parser.pos--;
       return true;
     }
   }

--- a/src/states/TAG_NAME.ts
+++ b/src/states/TAG_NAME.ts
@@ -110,8 +110,8 @@ export const TAG_NAME: StateDefinition<TagNameMeta> = {
       this.lookAtCharCodeAhead(1) === CODE.OPEN_CURLY_BRACE
     ) {
       this.pos += 2; // skip ${
+      this.forward = 0;
       this.enterState(STATE.EXPRESSION).terminator = CODE.CLOSE_CURLY_BRACE;
-      this.pos--;
     } else if (
       isWhitespaceCode(code) ||
       code === CODE.EQUAL ||


### PR DESCRIPTION
## Description

For some parser states we expect them to start on the character which they will process. In those cases it typically does a rewind just before entering the state. However a rewind will not work if the parser was already not going to go forward (eg exited a state).

This PR fixes the issue by changing all cases where we rewind to satisfy this to instead force the parser not to go forward.
This fixes an issue where sometime the parser would incorrectly see mismatched brackets.

## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->

<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [ ] I have updated/added documentation affected by my changes.
- [x] I have added tests to cover my changes.
