### PR TITLE
fix: make character positions for newlines the same as vscode

### DIFF
--- a/.changeset/clean-months-cheat.md
+++ b/.changeset/clean-months-cheat.md
@@ -1,0 +1,5 @@
+---
+"htmljs-parser": major
+---
+
+Switch character position offsets for newlines to be to similar to vscode. Previously the newline was counted as the first character of the line, now it is the last character of the previous line.

--- a/src/util/util.ts
+++ b/src/util/util.ts
@@ -41,10 +41,10 @@ export function getPos(
 }
 
 export function getLines(src: string) {
-  const lines = [-1];
+  const lines = [0];
   for (let i = 0; i < src.length; i++) {
     if (src.charCodeAt(i) === CODE.NEWLINE) {
-      lines.push(i);
+      lines.push(i + 1);
     }
   }
 


### PR DESCRIPTION
Switch character position offsets for newlines to be to similar to vscode. Previously the newline was counted as the first character of the line, now it is the last character of the previous line.