### PR TITLE
feat: improve js style comment support

### DIFF
--- a/.changeset/empty-trains-grin.md
+++ b/.changeset/empty-trains-grin.md
@@ -1,0 +1,5 @@
+---
+"htmljs-parser": patch
+---
+
+Support JS line comments inside the open tag (previously just block comments could be used).

--- a/.changeset/gold-radios-eat.md
+++ b/.changeset/gold-radios-eat.md
@@ -1,0 +1,5 @@
+---
+"htmljs-parser": patch
+---
+
+Support JS style comments in HTML bodies (previously allowed in parsed text and concise mode).

--- a/src/__tests__/fixtures/comments-within-open-tag/__snapshots__/comments-within-open-tag.expected.txt
+++ b/src/__tests__/fixtures/comments-within-open-tag/__snapshots__/comments-within-open-tag.expected.txt
@@ -11,3 +11,18 @@
  │  ││   ╰─ attrName "foo"
  │  │╰─ tagName "div"
  ╰─ ╰─ openTagStart
+2╭─ <div foo="bar" // this is a test
+ │  ││   │  │╰─ attrValue.value "\"bar\""
+ │  ││   │  ╰─ attrValue "=\"bar\""
+ │  ││   ╰─ attrName "foo"
+ │  │╰─ tagName "div"
+ ╰─ ╰─ openTagStart
+3╭─      hello="world" // this is another test
+ │       │    │╰─ attrValue.value "\"world\""
+ │       │    ╰─ attrValue "=\"world\""
+ ╰─      ╰─ attrName "hello"
+4╭─ ></div>
+ │  ││ │  ╰─ closeTagEnd(div)
+ │  ││ ╰─ closeTagName "div"
+ │  │╰─ closeTagStart "</"
+ ╰─ ╰─ openTagEnd

--- a/src/__tests__/fixtures/comments-within-open-tag/input.marko
+++ b/src/__tests__/fixtures/comments-within-open-tag/input.marko
@@ -1,1 +1,4 @@
 <div foo="bar" /*this is a comment*/ hello="world" /* this is another comment */ ></div>
+<div foo="bar" // this is a test
+     hello="world" // this is another test
+></div>

--- a/src/__tests__/fixtures/comments-within-tag-body/__snapshots__/comments-within-tag-body.expected.txt
+++ b/src/__tests__/fixtures/comments-within-tag-body/__snapshots__/comments-within-tag-body.expected.txt
@@ -1,0 +1,24 @@
+1╭─ <div>
+ │  ││  ╰─ openTagEnd
+ │  │╰─ tagName "div"
+ ╰─ ╰─ openTagStart
+2╭─      // This is a comment
+ │  │    │ ╰─ comment.value " This is a comment"
+ │  │    ╰─ comment "// This is a comment"
+ ╰─ ╰─ text "\n     "
+3╭─      This is some real text
+ ╰─ ╰─ text "\n     This is some real text\n     "
+4╭─      /* But this is a comment */
+ │       │ ╰─ comment.value " But this is a comment "
+ ╰─      ╰─ comment "/* But this is a comment */"
+5╭─      And this is more text
+ ╰─ ╰─ text "\n     And this is more text\n     "
+6╭─      <!-- and this is a comment -->
+ │       │   ╰─ comment.value " and this is a comment "
+ ╰─      ╰─ comment "<!-- and this is a comment -->"
+7╭─ </div>
+ │  │ │  ╰─ closeTagEnd(div)
+ │  │ ╰─ closeTagName "div"
+ │  ├─ text "\n"
+ ╰─ ╰─ closeTagStart "</"
+8╰─ 

--- a/src/__tests__/fixtures/comments-within-tag-body/input.marko
+++ b/src/__tests__/fixtures/comments-within-tag-body/input.marko
@@ -1,0 +1,7 @@
+<div>
+     // This is a comment
+     This is some real text
+     /* But this is a comment */
+     And this is more text
+     <!-- and this is a comment -->
+</div>

--- a/src/states/OPEN_TAG.ts
+++ b/src/states/OPEN_TAG.ts
@@ -273,14 +273,18 @@ export const OPEN_TAG: StateDefinition<OpenTagMeta> = {
       );
     }
 
-    if (
-      code === CODE.FORWARD_SLASH &&
-      this.lookAtCharCodeAhead(1) === CODE.ASTERISK
-    ) {
-      // Skip over code inside a JavaScript block comment
-      this.enterState(STATE.JS_COMMENT_BLOCK);
-      this.pos++; // skip *
-      return;
+    if (code === CODE.FORWARD_SLASH) {
+      // Check next character to see if we are in a comment
+      switch (this.lookAtCharCodeAhead(1)) {
+        case CODE.FORWARD_SLASH:
+          this.enterState(STATE.JS_COMMENT_LINE);
+          this.pos++; // skip /
+          return;
+        case CODE.ASTERISK:
+          this.enterState(STATE.JS_COMMENT_BLOCK);
+          this.pos++; // skip *
+          return;
+      }
     }
 
     if (isWhitespaceCode(code)) {


### PR DESCRIPTION
## Description

Adds better support for line comments within the open tag, eg:

```marko
<div class="foo" // this class is important
    onClick() {} // does stuff
>
```

This PR also makes the slightly breaking change of supporting JS style comments (both `//line` and `/*block*/`) within html content.

This means you can now do:

```marko
<div>
  // This is a comment
  This is not
 </div>
```

Previously you could only use js style comments within concise mode.

## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->

<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [ ] I have updated/added documentation affected by my changes.
- [x] I have added tests to cover my changes.
