### PR TITLE
fix: regex continuation issue

### DIFF
--- a/.changeset/gorgeous-laws-grin.md
+++ b/.changeset/gorgeous-laws-grin.md
@@ -1,0 +1,5 @@
+---
+"htmljs-parser": patch
+---
+
+Fix regression that causes incorrect expression continuations after regexps.

--- a/src/__tests__/fixtures/attr-regexp/__snapshots__/attr-regexp.expected.txt
+++ b/src/__tests__/fixtures/attr-regexp/__snapshots__/attr-regexp.expected.txt
@@ -1,0 +1,10 @@
+1╭─ <input pattern=/\s*?\S+\s*?/ name="test">
+ │  ││     │      ││             │   ││     ╰─ openTagEnd
+ │  ││     │      ││             │   │╰─ attrValue.value "\"test\""
+ │  ││     │      ││             │   ╰─ attrValue "=\"test\""
+ │  ││     │      ││             ╰─ attrName "name"
+ │  ││     │      │╰─ attrValue.value "/\\s*?\\S+\\s*?/"
+ │  ││     │      ╰─ attrValue "=/\\s*?\\S+\\s*?/"
+ │  ││     ╰─ attrName "pattern"
+ │  │╰─ tagName "input"
+ ╰─ ╰─ openTagStart

--- a/src/__tests__/fixtures/attr-regexp/input.marko
+++ b/src/__tests__/fixtures/attr-regexp/input.marko
@@ -1,0 +1,1 @@
+<input pattern=/\s*?\S+\s*?/ name="test">

--- a/src/__tests__/fixtures/comments-within-open-tag/__snapshots__/comments-within-open-tag.expected.txt
+++ b/src/__tests__/fixtures/comments-within-open-tag/__snapshots__/comments-within-open-tag.expected.txt
@@ -3,23 +3,23 @@
  │  ││   │  ││                           │    ││                                     ││ ╰─ closeTagName "div"
  │  ││   │  ││                           │    ││                                     │╰─ closeTagStart "</"
  │  ││   │  ││                           │    ││                                     ╰─ openTagEnd
- │  ││   │  ││                           │    │╰─ attrValue.value "\"world\""
- │  ││   │  ││                           │    ╰─ attrValue "=\"world\""
+ │  ││   │  ││                           │    │╰─ attrValue.value "\"world\" /* this is another comment */"
+ │  ││   │  ││                           │    ╰─ attrValue "=\"world\" /* this is another comment */"
  │  ││   │  ││                           ╰─ attrName "hello"
- │  ││   │  │╰─ attrValue.value "\"bar\""
- │  ││   │  ╰─ attrValue "=\"bar\""
+ │  ││   │  │╰─ attrValue.value "\"bar\" /*this is a comment*/"
+ │  ││   │  ╰─ attrValue "=\"bar\" /*this is a comment*/"
  │  ││   ╰─ attrName "foo"
  │  │╰─ tagName "div"
  ╰─ ╰─ openTagStart
 2╭─ <div foo="bar" // this is a test
- │  ││   │  │╰─ attrValue.value "\"bar\""
- │  ││   │  ╰─ attrValue "=\"bar\""
+ │  ││   │  │╰─ attrValue.value "\"bar\" // this is a test"
+ │  ││   │  ╰─ attrValue "=\"bar\" // this is a test"
  │  ││   ╰─ attrName "foo"
  │  │╰─ tagName "div"
  ╰─ ╰─ openTagStart
 3╭─      hello="world" // this is another test
- │       │    │╰─ attrValue.value "\"world\""
- │       │    ╰─ attrValue "=\"world\""
+ │       │    │╰─ attrValue.value "\"world\" // this is another test"
+ │       │    ╰─ attrValue "=\"world\" // this is another test"
  ╰─      ╰─ attrName "hello"
 4╭─ ></div>
  │  ││ │  ╰─ closeTagEnd(div)


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description

Fix regression that causes incorrect expression continuations after regexps.
Also causes comments directly after or inside attribute values to be included in the attribute value range.


## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->

<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [ ] I have updated/added documentation affected by my changes.
- [x] I have added tests to cover my changes.

<!--
Disclaimer: Contributions via GitHub pull requests are gladly accepted from their original author. Along with any pull requests, please state that the contribution is your original work and that you license the work to the project under the project's open source license. Whether or not you state this explicitly, by submitting any copyrighted material via pull request, email, or other means you agree to license the material under the project's open source license and warrant that you have the legal authority to do so.
-->
