### PR TITLE
fix: require a whitespace before js style comments inside html content

### DIFF
--- a/.changeset/wicked-mangos-camp.md
+++ b/.changeset/wicked-mangos-camp.md
@@ -1,0 +1,5 @@
+---
+"htmljs-parser": patch
+---
+
+Fix regression around JS style comments in the body by requiring that they are preceded by a whitespace.

--- a/src/__tests__/fixtures/comments-within-tag-body/__snapshots__/comments-within-tag-body.expected.txt
+++ b/src/__tests__/fixtures/comments-within-tag-body/__snapshots__/comments-within-tag-body.expected.txt
@@ -16,9 +16,19 @@
 6╭─      <!-- and this is a comment -->
  │       │   ╰─ comment.value " and this is a comment "
  ╰─      ╰─ comment "<!-- and this is a comment -->"
-7╭─ </div>
- │  │ │  ╰─ closeTagEnd(div)
- │  │ ╰─ closeTagName "div"
- │  ├─ text "\n"
- ╰─ ╰─ closeTagStart "</"
-8╰─ 
+7╭─      But this, this is not a http://comment.com
+ ╰─ ╰─ text "\n     But this, this is not a http://comment.com\n     And yet this is a "
+8╭─      And yet this is a //comment
+ │                         │ ╰─ comment.value "comment"
+ ╰─                        ╰─ comment "//comment"
+9╭─      And also /* this is a comment */
+ │  │             │ ╰─ comment.value " this is a comment "
+ │  │             ╰─ comment "/* this is a comment */"
+ ╰─ ╰─ text "\n     And also "
+10╭─      Because a//comment must be preceded by whitespace.
+  ╰─ ╰─ text "\n     Because a//comment must be preceded by whitespace.\n"
+11╭─ </div>
+  │  │ │  ╰─ closeTagEnd(div)
+  │  │ ╰─ closeTagName "div"
+  ╰─ ╰─ closeTagStart "</"
+12╰─ 

--- a/src/__tests__/fixtures/comments-within-tag-body/input.marko
+++ b/src/__tests__/fixtures/comments-within-tag-body/input.marko
@@ -4,4 +4,8 @@
      /* But this is a comment */
      And this is more text
      <!-- and this is a comment -->
+     But this, this is not a http://comment.com
+     And yet this is a //comment
+     And also /* this is a comment */
+     Because a//comment must be preceded by whitespace.
 </div>

--- a/src/states/HTML_CONTENT.ts
+++ b/src/states/HTML_CONTENT.ts
@@ -94,7 +94,10 @@ export const HTML_CONTENT: StateDefinition<HTMLContentMeta> = {
       this.endText();
       this.enterState(STATE.INLINE_SCRIPT);
       this.pos++; // skip space
-    } else if (code === CODE.FORWARD_SLASH) {
+    } else if (
+      code === CODE.FORWARD_SLASH &&
+      isWhitespaceCode(this.lookAtCharCodeAhead(-1))
+    ) {
       // Check next character to see if we are in a comment
       switch (this.lookAtCharCodeAhead(1)) {
         case CODE.FORWARD_SLASH:


### PR DESCRIPTION
## Description

Fix regression around JS style comments in the body by requiring that they are preceded by a whitespace.

## Motivation and Context

This was caused by #119 which noted that this was potentially a breaking change. We didn't for see a common edge case however which was http links inside some content, eg:

```marko
<a href="http://ebay.com">
  http://ebay.com
</a>
```

With #119 that caused the code above to treat `//ebay.com` as a JS comment which was not desirable.
Now by requiring a whitespace (eg a newline) before any JS style comments within the html content we avoid this common gotcha while maintaining support for this syntax/feature.

## Checklist:

- [ ] I have updated/added documentation affected by my changes.
- [x] I have added tests to cover my changes.

<!--
Disclaimer: Contributions via GitHub pull requests are gladly accepted from their original author. Along with any pull requests, please state that the contribution is your original work and that you license the work to the project under the project's open source license. Whether or not you state this explicitly, by submitting any copyrighted material via pull request, email, or other means you agree to license the material under the project's open source license and warrant that you have the legal authority to do so.
-->
