### PR TITLE
fix: regression with comments inside parsed text state

### DIFF
--- a/.changeset/neat-cobras-battle.md
+++ b/.changeset/neat-cobras-battle.md
@@ -1,0 +1,5 @@
+---
+"htmljs-parser": patch
+---
+
+Fix regression which caused script tags with a trailing comment as the same line as the closing tag to not always parse properly.

--- a/.changeset/quick-seals-watch.md
+++ b/.changeset/quick-seals-watch.md
@@ -1,0 +1,5 @@
+---
+"htmljs-parser": patch
+---
+
+Remove unecessary check for cdata inside parsed text state.

--- a/src/__tests__/fixtures/cdata/__snapshots__/cdata.expected.txt
+++ b/src/__tests__/fixtures/cdata/__snapshots__/cdata.expected.txt
@@ -1,9 +1,3 @@
-1╭─ <html-comment><![CDATA[[if lt IE 9]><div><![endif]]]></html-comment>
- │  ││           ││        │                             │ │           ╰─ closeTagEnd(html-comment)
- │  ││           ││        │                             │ ╰─ closeTagName "html-comment"
- │  ││           ││        │                             ╰─ closeTagStart "</"
- │  ││           ││        ╰─ cdata.value "[if lt IE 9]><div><![endif]"
- │  ││           │╰─ cdata "<![CDATA[[if lt IE 9]><div><![endif]]]>"
- │  ││           ╰─ openTagEnd
- │  │╰─ tagName "html-comment"
- ╰─ ╰─ openTagStart
+1╭─ <![CDATA[[if lt IE 9]><div><![endif]]]>
+ │  │        ╰─ cdata.value "[if lt IE 9]><div><![endif]"
+ ╰─ ╰─ cdata "<![CDATA[[if lt IE 9]><div><![endif]]]>"

--- a/src/__tests__/fixtures/cdata/input.marko
+++ b/src/__tests__/fixtures/cdata/input.marko
@@ -1,1 +1,1 @@
-<html-comment><![CDATA[[if lt IE 9]><div><![endif]]]></html-comment>
+<![CDATA[[if lt IE 9]><div><![endif]]]>

--- a/src/__tests__/fixtures/script-single-line-comment/__snapshots__/script-single-line-comment.expected.txt
+++ b/src/__tests__/fixtures/script-single-line-comment/__snapshots__/script-single-line-comment.expected.txt
@@ -6,3 +6,32 @@
  │  ││     ╰─ openTagEnd
  │  │╰─ tagName "script"
  ╰─ ╰─ openTagStart
+2├─ 
+3╭─ <div>
+ │  ││  ╰─ openTagEnd
+ │  │╰─ tagName "div"
+ ╰─ ╰─ openTagStart
+4╭─   <script>// this is a comment</script>
+ │  │ ││     ││                   │ │     ╰─ closeTagEnd(script)
+ │  │ ││     ││                   │ ╰─ closeTagName "script"
+ │  │ ││     ││                   ╰─ closeTagStart "</"
+ │  │ ││     │╰─ text "// this is a comment"
+ │  │ ││     ╰─ openTagEnd
+ │  │ │╰─ tagName "script"
+ │  │ ╰─ openTagStart
+ ╰─ ╰─ text "\n  "
+5╭─   <span>hi</span>
+ │  │ ││   ││ │ │   ╰─ closeTagEnd(span)
+ │  │ ││   ││ │ ╰─ closeTagName "span"
+ │  │ ││   ││ ╰─ closeTagStart "</"
+ │  │ ││   │╰─ text "hi"
+ │  │ ││   ╰─ openTagEnd
+ │  │ │╰─ tagName "span"
+ │  │ ╰─ openTagStart
+ ╰─ ╰─ text "\n  "
+6╭─ </div>
+ │  │ │  ╰─ closeTagEnd(div)
+ │  │ ╰─ closeTagName "div"
+ │  ├─ text "\n"
+ ╰─ ╰─ closeTagStart "</"
+7╰─ 

--- a/src/__tests__/fixtures/script-single-line-comment/input.marko
+++ b/src/__tests__/fixtures/script-single-line-comment/input.marko
@@ -1,1 +1,6 @@
 <script>// this is a comment</script>
+
+<div>
+  <script>// this is a comment</script>
+  <span>hi</span>
+</div>

--- a/src/states/JS_COMMENT_LINE.ts
+++ b/src/states/JS_COMMENT_LINE.ts
@@ -21,11 +21,12 @@ export const JS_COMMENT_LINE: StateDefinition = {
     if (
       !this.isConcise &&
       code === CODE.OPEN_ANGLE_BRACKET &&
-      this.activeTag?.type === TagType.text
+      this.activeTag?.type === TagType.text &&
+      STATE.checkForClosingTag(this)
     ) {
-      // First, see if we need to see if we reached the closing tag
+      // We need to see if we reached the closing tag
       // eg: <script>//foo</script>
-      STATE.checkForClosingTag(this);
+      this.exitState();
     }
   },
 

--- a/src/states/PARSED_TEXT_CONTENT.ts
+++ b/src/states/PARSED_TEXT_CONTENT.ts
@@ -29,10 +29,7 @@ export const PARSED_TEXT_CONTENT: StateDefinition<ParsedTextContentMeta> = {
   char(code) {
     switch (code) {
       case CODE.OPEN_ANGLE_BRACKET:
-        if (
-          this.isConcise ||
-          !(STATE.checkForClosingTag(this) || STATE.checkForCDATA(this))
-        ) {
+        if (this.isConcise || !STATE.checkForClosingTag(this)) {
           this.startText();
         }
         break;


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description

Fixes an issue where parsed text state tags (eg `<script>`) were not properly being ended if the line ended with a comment.
This was a regression.

```
<script>// This should close even though there is a line comment on the same line</script>
```

## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->

<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [ ] I have updated/added documentation affected by my changes.
- [x] I have added tests to cover my changes.

<!--
Disclaimer: Contributions via GitHub pull requests are gladly accepted from their original author. Along with any pull requests, please state that the contribution is your original work and that you license the work to the project under the project's open source license. Whether or not you state this explicitly, by submitting any copyrighted material via pull request, email, or other means you agree to license the material under the project's open source license and warrant that you have the legal authority to do so.
-->
