### PR TITLE
fix: issue with parsing division followed by encloused code

### DIFF
--- a/.changeset/mean-buses-mate.md
+++ b/.changeset/mean-buses-mate.md
@@ -1,0 +1,5 @@
+---
+"htmljs-parser": patch
+---
+
+Fixes a parse error where division is immediately followed by enclosed code.

--- a/src/__tests__/fixtures/attr-method-shorthand/__snapshots__/attr-method-shorthand.expected.txt
+++ b/src/__tests__/fixtures/attr-method-shorthand/__snapshots__/attr-method-shorthand.expected.txt
@@ -173,6 +173,18 @@
   ╰─ ╰─ tagName "foo"
 59├─   console.log("hello"); 
 60├─   event.preventDefault();
-61╭─ }
-  │   ├─ closeTagEnd(foo)
-  ╰─  ╰─ openTagEnd
+61├─ }
+62╭─ 
+  ╰─ ╰─ openTagEnd
+63╭─ <a b() { c / (d) }/>
+  │  ││ │││ ││         ╰─ openTagEnd:selfClosed "/>"
+  │  ││ │││ │╰─ attrMethod.body.value " c / (d) "
+  │  ││ │││ ╰─ attrMethod.body "{ c / (d) }"
+  │  ││ ││╰─ attrMethod.params.value
+  │  ││ │├─ attrMethod.params "()"
+  │  ││ │╰─ attrMethod "() { c / (d) }"
+  │  ││ ╰─ attrName
+  │  │╰─ tagName
+  │  ├─ closeTagEnd(foo)
+  ╰─ ╰─ openTagStart
+64╰─ 

--- a/src/__tests__/fixtures/attr-method-shorthand/input.marko
+++ b/src/__tests__/fixtures/attr-method-shorthand/input.marko
@@ -59,3 +59,5 @@ foo (event) {
   console.log("hello"); 
   event.preventDefault();
 }
+
+<a b() { c / (d) }/>

--- a/src/__tests__/fixtures/attr-operators-space-between/__snapshots__/attr-operators-space-between.expected.txt
+++ b/src/__tests__/fixtures/attr-operators-space-between/__snapshots__/attr-operators-space-between.expected.txt
@@ -1033,3 +1033,10 @@
    │  ││╰─ attrName
    │  │╰─ tagName
    ╰─ ╰─ openTagStart
+128╭─ <a= x / (y[z])/>
+   │  │││ │         ╰─ openTagEnd:selfClosed "/>"
+   │  │││ ╰─ attrValue.value "x / (y[z])"
+   │  ││├─ attrValue "= x / (y[z])"
+   │  ││╰─ attrName
+   │  │╰─ tagName
+   ╰─ ╰─ openTagStart

--- a/src/__tests__/fixtures/attr-operators-space-between/input.marko
+++ b/src/__tests__/fixtures/attr-operators-space-between/input.marko
@@ -125,3 +125,4 @@ a = async function (x) { console.log("y") } a
 <a= function (x) { console.log("y") } a/>
 <a= x => { console.log("y") } a/>
 <a= async function (x) { console.log("y") } a/>
+<a= x / (y[z])/>

--- a/src/states/EXPRESSION.ts
+++ b/src/states/EXPRESSION.ts
@@ -90,6 +90,7 @@ export const EXPRESSION: StateDefinition<ExpressionMeta> = {
           default: {
             if (canFollowDivision(this.getPreviousNonWhitespaceCharCode())) {
               this.pos++;
+              this.forward = 0;
               this.consumeWhitespace();
             } else {
               this.enterState(STATE.REGULAR_EXPRESSION);


### PR DESCRIPTION
## Description

Fixes a parse error where division is immediately followed by enclosed code.

Specifically if an expression looked something like
```js
x / (y[z])
```
When the parser encountered division it consumed the whitespace and went one character ahead. In the above example that'd cause it to skip over the `(` which caused the enclosed expression tracking to be off. 

## Checklist:

- [ ] I have updated/added documentation affected by my changes.
- [x] I have added tests to cover my changes.
