### PR TITLE
fix: ensure keyword operators are always followed by a space

### DIFF
--- a/.changeset/beige-seahorses-talk.md
+++ b/.changeset/beige-seahorses-talk.md
@@ -1,0 +1,5 @@
+---
+"htmljs-parser": patch
+---
+
+Fixes an issue where attribute names that started with a keyword (eg: `as-thing` or `instanceof-thing`) were incorrectly treated as an expression continuation.

--- a/src/__tests__/fixtures/attr-complex-instanceof/__snapshots__/attr-complex-instanceof.expected.txt
+++ b/src/__tests__/fixtures/attr-complex-instanceof/__snapshots__/attr-complex-instanceof.expected.txt
@@ -44,17 +44,34 @@
  ╰─ ╰─ tagName "tag"
 7╭─ 
  ╰─ ╰─ openTagEnd
-8╭─ tag a = 'foo' instanceof, b
- │  │   │ │ │     │           ╰─ attrName
- │  │   │ │ │     ╰─ attrName "instanceof"
+8╭─ tag a = 'foo' instanceof-test;
+ │  │   │ │ │     ╰─ attrName "instanceof-test"
  │  │   │ │ ╰─ attrValue.value "'foo'"
  │  │   │ ╰─ attrValue "= 'foo'"
  │  │   ╰─ attrName
  │  ├─ closeTagEnd(tag)
  ╰─ ╰─ tagName "tag"
-9╭─ 
- ╰─ ╰─ openTagEnd
-10╭─ <tag a = 'foo' instanceof></tag>
+9╭─ tag a = 'foo' instanceof_test;
+ │  │   │ │ │     ╰─ attrName "instanceof_test"
+ │  │   │ │ ╰─ attrValue.value "'foo'"
+ │  │   │ ╰─ attrValue "= 'foo'"
+ │  │   ╰─ attrName
+ │  ├─ closeTagEnd(tag)
+ │  ├─ openTagEnd
+ ╰─ ╰─ tagName "tag"
+10╭─ 
+  ╰─ ╰─ openTagEnd
+11╭─ tag a = 'foo' instanceof, b
+  │  │   │ │ │     │           ╰─ attrName
+  │  │   │ │ │     ╰─ attrName "instanceof"
+  │  │   │ │ ╰─ attrValue.value "'foo'"
+  │  │   │ ╰─ attrValue "= 'foo'"
+  │  │   ╰─ attrName
+  │  ├─ closeTagEnd(tag)
+  ╰─ ╰─ tagName "tag"
+12╭─ 
+  ╰─ ╰─ openTagEnd
+13╭─ <tag a = 'foo' instanceof></tag>
   │  ││   │ │ │     │         ││ │  ╰─ closeTagEnd(tag)
   │  ││   │ │ │     │         ││ ╰─ closeTagName "tag"
   │  ││   │ │ │     │         │╰─ closeTagStart "</"
@@ -66,7 +83,7 @@
   │  │╰─ tagName "tag"
   │  ├─ closeTagEnd(tag)
   ╰─ ╰─ openTagStart
-11╭─ <tag a = 'foo' instanceof/>
+14╭─ <tag a = 'foo' instanceof/>
   │  ││   │ │ │     │         ╰─ openTagEnd:selfClosed "/>"
   │  ││   │ │ │     ╰─ attrName "instanceof"
   │  ││   │ │ ╰─ attrValue.value "'foo'"
@@ -74,17 +91,17 @@
   │  ││   ╰─ attrName
   │  │╰─ tagName "tag"
   ╰─ ╰─ openTagStart
-12├─ 
-13╭─ tag a = 'foo' instanceofthing String
+15├─ 
+16╭─ tag a = 'foo' instanceofthing String
   │  │   │ │ │     │               ╰─ attrName "String"
   │  │   │ │ │     ╰─ attrName "instanceofthing"
   │  │   │ │ ╰─ attrValue.value "'foo'"
   │  │   │ ╰─ attrValue "= 'foo'"
   │  │   ╰─ attrName
   ╰─ ╰─ tagName "tag"
-14╭─ 
+17╭─ 
   ╰─ ╰─ openTagEnd
-15╭─ tag a = 'foo' instanceof
+18╭─ tag a = 'foo' instanceof
   │  │   │ │ │     │         ├─ closeTagEnd(tag)
   │  │   │ │ │     │         ╰─ openTagEnd
   │  │   │ │ │     ╰─ attrName "instanceof"

--- a/src/__tests__/fixtures/attr-complex-instanceof/input.marko
+++ b/src/__tests__/fixtures/attr-complex-instanceof/input.marko
@@ -5,6 +5,9 @@ tag a = 'foo' instanceof := String
 tag a = 'foo' instanceof= String
 tag a = 'foo' instanceof;
 
+tag a = 'foo' instanceof-test;
+tag a = 'foo' instanceof_test;
+
 tag a = 'foo' instanceof, b
 
 <tag a = 'foo' instanceof></tag>

--- a/src/states/EXPRESSION.ts
+++ b/src/states/EXPRESSION.ts
@@ -342,8 +342,8 @@ function lookAheadForOperator(data: string, pos: number): number {
           nextPos = lookAheadWhile(isWhitespaceCode, data, nextPos + 2);
           if (nextPos === max) return -1;
           nextCode = data.charCodeAt(nextPos);
-        } else if (isWordCode(nextCode)) {
-          // bail if we are continuing a word, eg "**in**teger"
+        } else {
+          // bail if we didn't match a space keyword.
           return -1;
         }
 


### PR DESCRIPTION
Fixes an issue where attribute names that started with a keyword (eg: `as-thing` or `instanceof-thing`) were incorrectly treated as an expression continuation.