### PR TITLE
fix: tag variable not terminated on concise mode text delimiter

### DIFF
--- a/.changeset/lovely-chefs-pump.md
+++ b/.changeset/lovely-chefs-pump.md
@@ -1,0 +1,5 @@
+---
+"htmljs-parser": patch
+---
+
+Fix issue with tag variable not terminated on concise mode text delimiter

--- a/src/__tests__/fixtures/tag-var-before-concise-text/__snapshots__/tag-var-before-concise-text.expected.txt
+++ b/src/__tests__/fixtures/tag-var-before-concise-text/__snapshots__/tag-var-before-concise-text.expected.txt
@@ -1,0 +1,11 @@
+1╭─ style/style --
+ │  │    ││     ╰─ openTagEnd
+ │  │    │╰─ tagVar.value "style"
+ │  │    ╰─ tagVar "/style"
+ ╰─ ╰─ tagName "style"
+2╭─   header {
+ ╰─ ╰─ text "\n  header {\n    color: green\n  }\n"
+3├─     color: green
+4├─   }
+5╭─ 
+ ╰─ ╰─ closeTagEnd(style)

--- a/src/__tests__/fixtures/tag-var-before-concise-text/input.marko
+++ b/src/__tests__/fixtures/tag-var-before-concise-text/input.marko
@@ -1,0 +1,4 @@
+style/style --
+  header {
+    color: green
+  }

--- a/src/__tests__/main.test.ts
+++ b/src/__tests__/main.test.ts
@@ -176,7 +176,7 @@ for (const entry of fs.readdirSync(FIXTURES)) {
       onOpenTagEnd(range) {
         if (range.selfClosed) tagStack.pop();
         else
-          switch (tagStack.at(-1)!.type) {
+          switch (tagStack[tagStack.length - 1]!.type) {
             case TagType.statement:
             case TagType.void:
               tagStack.pop();

--- a/src/states/OPEN_TAG.ts
+++ b/src/states/OPEN_TAG.ts
@@ -478,6 +478,8 @@ function shouldTerminateConciseTagVar(code: number, data: string, pos: number) {
     case CODE.SEMICOLON:
     case CODE.OPEN_ANGLE_BRACKET:
       return true;
+    case CODE.HYPHEN:
+      return data.charCodeAt(pos + 1) === CODE.HYPHEN;
     case CODE.COLON:
       return data.charCodeAt(pos + 1) === CODE.EQUAL;
     default:


### PR DESCRIPTION
## Description

The following would cause the parser to see the `-` after the tag var as an expression continuation instead of beginning a concise text block.

```marko
style/style --
  header {
    color: green
  }
```
