### PR TITLE
fix: ensure unary expression continuation is a word boundary

### DIFF
--- a/.changeset/stale-impalas-visit.md
+++ b/.changeset/stale-impalas-visit.md
@@ -1,0 +1,5 @@
+---
+"htmljs-parser": patch
+---
+
+Fix regression where the parser would continue unary keyword expressions even if the keyword was inside a word boundary. Eg `<div class=thing_new x>` would cause the parser to see the expression as `thing_` and `new x`.

--- a/src/__tests__/fixtures/attr-complex-unary/__snapshots__/attr-complex-unary.expected.txt
+++ b/src/__tests__/fixtures/attr-complex-unary/__snapshots__/attr-complex-unary.expected.txt
@@ -1,0 +1,80 @@
+1╭─ tag a = class b {}
+ │  │   │ │ ╰─ attrValue.value "class b {}"
+ │  │   │ ╰─ attrValue "= class b {}"
+ │  │   ╰─ attrName
+ ╰─ ╰─ tagName "tag"
+2╭─ 
+ ╰─ ╰─ openTagEnd
+3╭─ tag a = class, b
+ │  │   │ │ │      ╰─ attrName
+ │  │   │ │ ╰─ attrValue.value "class"
+ │  │   │ ╰─ attrValue "= class"
+ │  │   ╰─ attrName
+ │  ├─ closeTagEnd(tag)
+ ╰─ ╰─ tagName "tag"
+4╭─ 
+ ╰─ ╰─ openTagEnd
+5╭─ <tag a = class></tag>
+ │  ││   │ │ │    ││ │  ╰─ closeTagEnd(tag)
+ │  ││   │ │ │    ││ ╰─ closeTagName "tag"
+ │  ││   │ │ │    │╰─ closeTagStart "</"
+ │  ││   │ │ │    ╰─ openTagEnd
+ │  ││   │ │ ╰─ attrValue.value "class"
+ │  ││   │ ╰─ attrValue "= class"
+ │  ││   ╰─ attrName
+ │  │╰─ tagName "tag"
+ │  ├─ closeTagEnd(tag)
+ ╰─ ╰─ openTagStart
+6├─ 
+7╭─ <tag a = class/>
+ │  ││   │ │ │    ╰─ openTagEnd:selfClosed "/>"
+ │  ││   │ │ ╰─ attrValue.value "class"
+ │  ││   │ ╰─ attrValue "= class"
+ │  ││   ╰─ attrName
+ │  │╰─ tagName "tag"
+ ╰─ ╰─ openTagStart
+8├─ 
+9╭─ tag a = classthing b
+ │  │   │ │ │          ╰─ attrName
+ │  │   │ │ ╰─ attrValue.value "classthing"
+ │  │   │ ╰─ attrValue "= classthing"
+ │  │   ╰─ attrName
+ ╰─ ╰─ tagName "tag"
+10╭─ 
+  ╰─ ╰─ openTagEnd
+11╭─ tag a = testclass b
+  │  │   │ │ │         ╰─ attrName
+  │  │   │ │ ╰─ attrValue.value "testclass"
+  │  │   │ ╰─ attrValue "= testclass"
+  │  │   ╰─ attrName
+  │  ├─ closeTagEnd(tag)
+  ╰─ ╰─ tagName "tag"
+12╭─ 
+  ╰─ ╰─ openTagEnd
+13╭─ tag a = test_class b
+  │  │   │ │ │          ╰─ attrName
+  │  │   │ │ ╰─ attrValue.value "test_class"
+  │  │   │ ╰─ attrValue "= test_class"
+  │  │   ╰─ attrName
+  │  ├─ closeTagEnd(tag)
+  ╰─ ╰─ tagName "tag"
+14╭─ 
+  ╰─ ╰─ openTagEnd
+15╭─ tag a = test$class b
+  │  │   │ │ │          ╰─ attrName
+  │  │   │ │ ╰─ attrValue.value "test$class"
+  │  │   │ ╰─ attrValue "= test$class"
+  │  │   ╰─ attrName
+  │  ├─ closeTagEnd(tag)
+  ╰─ ╰─ tagName "tag"
+16╭─ 
+  ╰─ ╰─ openTagEnd
+17╭─ tag a = test+class b
+  │  │   │ │ ╰─ attrValue.value "test+class b"
+  │  │   │ ╰─ attrValue "= test+class b"
+  │  │   ╰─ attrName
+  │  ├─ closeTagEnd(tag)
+  ╰─ ╰─ tagName "tag"
+18╭─ 
+  │  ├─ openTagEnd
+  ╰─ ╰─ closeTagEnd(tag)

--- a/src/__tests__/fixtures/attr-complex-unary/input.marko
+++ b/src/__tests__/fixtures/attr-complex-unary/input.marko
@@ -1,0 +1,17 @@
+tag a = class b {}
+
+tag a = class, b
+
+<tag a = class></tag>
+
+<tag a = class/>
+
+tag a = classthing b
+
+tag a = testclass b
+
+tag a = test_class b
+
+tag a = test$class b
+
+tag a = test+class b

--- a/src/states/EXPRESSION.ts
+++ b/src/states/EXPRESSION.ts
@@ -296,7 +296,8 @@ function lookBehindForOperator(data: string, pos: number): number {
       for (const keyword of unaryKeywords) {
         const keywordPos = lookBehindFor(data, curPos, keyword);
         if (keywordPos !== -1) {
-          return data.charCodeAt(keywordPos - 1) === CODE.PERIOD
+          const prevCode = data.charCodeAt(keywordPos - 1);
+          return prevCode === CODE.PERIOD || isWordCode(prevCode)
             ? -1
             : keywordPos;
         }


### PR DESCRIPTION
## Description

Fix regression where the parser would continue unary keyword expressions even if the keyword was inside a word boundary. Eg `<div class=thing_new x>` would cause the parser to see the expression as `thing_` and `new x`.

## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->

<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [ ] I have updated/added documentation affected by my changes.
- [x] I have added tests to cover my changes.

<!--
Disclaimer: Contributions via GitHub pull requests are gladly accepted from their original author. Along with any pull requests, please state that the contribution is your original work and that you license the work to the project under the project's open source license. Whether or not you state this explicitly, by submitting any copyrighted material via pull request, email, or other means you agree to license the material under the project's open source license and warrant that you have the legal authority to do so.
-->
