### PR TITLE
fix: parsed text string literals

### DIFF
--- a/.changeset/eight-shirts-dream.md
+++ b/.changeset/eight-shirts-dream.md
@@ -1,0 +1,5 @@
+---
+"htmljs-parser": patch
+---
+
+Fixes an regression where string literals inside of parsed text nodes (eg `<script>`) were not properly changing the parser state. This caused issues when comment like syntax was embedded within these string literals"

--- a/src/__tests__/fixtures/script-with-strings/__snapshots__/script-with-strings.expected.txt
+++ b/src/__tests__/fixtures/script-with-strings/__snapshots__/script-with-strings.expected.txt
@@ -1,0 +1,30 @@
+1╭─ <script>
+ │  ││     ╰─ openTagEnd
+ │  │╰─ tagName "script"
+ ╰─ ╰─ openTagStart
+2╭─   "this is a ${test}"
+ │  │            │ ╰─ placeholder:escape.value "test"
+ │  │            ╰─ placeholder:escape "${test}"
+ ╰─ ╰─ text "\n  \"this is a "
+3╭─   "this is a \${test}"
+ │  │             ╰─ text "${test}\"\n  \"/*\"\n  \"//\"\n  'this is a "
+ ╰─ ╰─ text "\n  \"this is a "
+4├─   "/*"
+5├─   "//"
+6╭─   'this is a ${test}'
+ │               │ ╰─ placeholder:escape.value "test"
+ ╰─              ╰─ placeholder:escape "${test}"
+7╭─   'this is a \${test}'
+ │  │             ╰─ text "${test}'\n  '/*'\n  '//'\n  `this is a ${test}`\n  `this is a \\${test}`\n  `/*`\n  `//`\n"
+ ╰─ ╰─ text "\n  'this is a "
+8├─   '/*'
+9├─   '//'
+10├─   `this is a ${test}`
+11├─   `this is a \${test}`
+12├─   `/*`
+13├─   `//`
+14╭─ </script>
+  │  │ │     ╰─ closeTagEnd(script)
+  │  │ ╰─ closeTagName "script"
+  ╰─ ╰─ closeTagStart "</"
+15╰─ 

--- a/src/__tests__/fixtures/script-with-strings/input.marko
+++ b/src/__tests__/fixtures/script-with-strings/input.marko
@@ -1,0 +1,14 @@
+<script>
+  "this is a ${test}"
+  "this is a \${test}"
+  "/*"
+  "//"
+  'this is a ${test}'
+  'this is a \${test}'
+  '/*'
+  '//'
+  `this is a ${test}`
+  `this is a \${test}`
+  `/*`
+  `//`
+</script>

--- a/src/states/PARSED_STRING.ts
+++ b/src/states/PARSED_STRING.ts
@@ -1,0 +1,42 @@
+import { CODE, ErrorCode, STATE, StateDefinition, Meta } from "../internal";
+
+interface ParsedStringMeta extends Meta {
+  quoteCharCode: number;
+}
+
+export const PARSED_STRING: StateDefinition<ParsedStringMeta> = {
+  name: "PARSED_STRING",
+
+  enter(parent, start) {
+    return {
+      state: PARSED_STRING,
+      parent,
+      start,
+      end: start,
+      quoteCharCode: CODE.DOUBLE_QUOTE,
+    } as ParsedStringMeta;
+  },
+
+  exit() {},
+
+  char(code, str) {
+    if (code === str.quoteCharCode) {
+      this.pos++; // skip end quote
+      this.exitState();
+    } else if (!STATE.checkForPlaceholder(this, code)) {
+      this.startText();
+    }
+  },
+
+  eof(str) {
+    this.emitError(
+      str,
+      ErrorCode.INVALID_TEMPLATE_STRING,
+      "EOF reached while parsing string expression"
+    );
+  },
+
+  eol() {},
+
+  return() {},
+};

--- a/src/states/PARSED_TEXT_CONTENT.ts
+++ b/src/states/PARSED_TEXT_CONTENT.ts
@@ -50,6 +50,12 @@ export const PARSED_TEXT_CONTENT: StateDefinition<ParsedTextContentMeta> = {
         this.startText();
         this.enterState(STATE.TEMPLATE_STRING);
         break;
+      case CODE.DOUBLE_QUOTE:
+      case CODE.SINGLE_QUOTE:
+        this.startText();
+        this.enterState(STATE.PARSED_STRING).quoteCharCode = code;
+        break;
+
       default:
         if (!STATE.checkForPlaceholder(this, code)) this.startText();
         break;

--- a/src/states/index.ts
+++ b/src/states/index.ts
@@ -17,4 +17,5 @@ export * from "./REGULAR_EXPRESSION";
 export * from "./STRING";
 export * from "./TAG_NAME";
 export * from "./TEMPLATE_STRING";
+export * from "./PARSED_STRING";
 export * from "./OPEN_TAG";


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description

Fixes an regression where string literals inside of parsed text nodes (eg `<script>`) were not properly changing the parser state. This caused issues when comment like syntax was embedded within these string literals"

- [ ] I have updated/added documentation affected by my changes.
- [x] I have added tests to cover my changes.

<!--
Disclaimer: Contributions via GitHub pull requests are gladly accepted from their original author. Along with any pull requests, please state that the contribution is your original work and that you license the work to the project under the project's open source license. Whether or not you state this explicitly, by submitting any copyrighted material via pull request, email, or other means you agree to license the material under the project's open source license and warrant that you have the legal authority to do so.
-->
