### PR TITLE
fix: always consume terminator if it is preceded by an operator

### DIFF
--- a/.changeset/tall-moons-enjoy.md
+++ b/.changeset/tall-moons-enjoy.md
@@ -1,0 +1,5 @@
+---
+"htmljs-parser": patch
+---
+
+Always consume next character of expression if terminator was preceded by an operator.

--- a/src/__tests__/fixtures/attr-complex-unary/__snapshots__/attr-complex-unary.expected.txt
+++ b/src/__tests__/fixtures/attr-complex-unary/__snapshots__/attr-complex-unary.expected.txt
@@ -5,31 +5,31 @@
  ╰─ ╰─ tagName "tag"
 2╭─ 
  ╰─ ╰─ openTagEnd
-3╭─ tag a = class, b
- │  │   │ │ │      ╰─ attrName
- │  │   │ │ ╰─ attrValue.value "class"
- │  │   │ ╰─ attrValue "= class"
+3╭─ tag a = class {}, b
+ │  │   │ │ │         ╰─ attrName
+ │  │   │ │ ╰─ attrValue.value "class {}"
+ │  │   │ ╰─ attrValue "= class {}"
  │  │   ╰─ attrName
  │  ├─ closeTagEnd(tag)
  ╰─ ╰─ tagName "tag"
 4╭─ 
  ╰─ ╰─ openTagEnd
-5╭─ <tag a = class></tag>
- │  ││   │ │ │    ││ │  ╰─ closeTagEnd(tag)
- │  ││   │ │ │    ││ ╰─ closeTagName "tag"
- │  ││   │ │ │    │╰─ closeTagStart "</"
- │  ││   │ │ │    ╰─ openTagEnd
- │  ││   │ │ ╰─ attrValue.value "class"
- │  ││   │ ╰─ attrValue "= class"
+5╭─ <tag a = class {}></tag>
+ │  ││   │ │ │       ││ │  ╰─ closeTagEnd(tag)
+ │  ││   │ │ │       ││ ╰─ closeTagName "tag"
+ │  ││   │ │ │       │╰─ closeTagStart "</"
+ │  ││   │ │ │       ╰─ openTagEnd
+ │  ││   │ │ ╰─ attrValue.value "class {}"
+ │  ││   │ ╰─ attrValue "= class {}"
  │  ││   ╰─ attrName
  │  │╰─ tagName "tag"
  │  ├─ closeTagEnd(tag)
  ╰─ ╰─ openTagStart
 6├─ 
-7╭─ <tag a = class/>
- │  ││   │ │ │    ╰─ openTagEnd:selfClosed "/>"
- │  ││   │ │ ╰─ attrValue.value "class"
- │  ││   │ ╰─ attrValue "= class"
+7╭─ <tag a = class {}/>
+ │  ││   │ │ │       ╰─ openTagEnd:selfClosed "/>"
+ │  ││   │ │ ╰─ attrValue.value "class {}"
+ │  ││   │ ╰─ attrValue "= class {}"
  │  ││   ╰─ attrName
  │  │╰─ tagName "tag"
  ╰─ ╰─ openTagStart
@@ -69,9 +69,9 @@
   ╰─ ╰─ tagName "tag"
 16╭─ 
   ╰─ ╰─ openTagEnd
-17╭─ tag a = test+class b
-  │  │   │ │ ╰─ attrValue.value "test+class b"
-  │  │   │ ╰─ attrValue "= test+class b"
+17╭─ tag a = test+class b {}
+  │  │   │ │ ╰─ attrValue.value "test+class b {}"
+  │  │   │ ╰─ attrValue "= test+class b {}"
   │  │   ╰─ attrName
   │  ├─ closeTagEnd(tag)
   ╰─ ╰─ tagName "tag"

--- a/src/__tests__/fixtures/attr-complex-unary/input.marko
+++ b/src/__tests__/fixtures/attr-complex-unary/input.marko
@@ -1,10 +1,10 @@
 tag a = class b {}
 
-tag a = class, b
+tag a = class {}, b
 
-<tag a = class></tag>
+<tag a = class {}></tag>
 
-<tag a = class/>
+<tag a = class {}/>
 
 tag a = classthing b
 
@@ -14,4 +14,4 @@ tag a = test_class b
 
 tag a = test$class b
 
-tag a = test+class b
+tag a = test+class b {}

--- a/src/__tests__/fixtures/tag-var-type-with-parens/__snapshots__/tag-var-type-with-parens.expected.txt
+++ b/src/__tests__/fixtures/tag-var-type-with-parens/__snapshots__/tag-var-type-with-parens.expected.txt
@@ -1,0 +1,50 @@
+1╭─ let/a:(B | C) = D
+ │  │  ││         │ ╰─ attrValue.value
+ │  │  ││         ├─ attrValue "= D"
+ │  │  ││         ╰─ attrName
+ │  │  │╰─ tagVar.value "a:(B | C)"
+ │  │  ╰─ tagVar "/a:(B | C)"
+ ╰─ ╰─ tagName "let"
+2╭─ 
+ ╰─ ╰─ openTagEnd
+3╭─ let/a: (B | C) = D
+ │  │  ││          │ ╰─ attrValue.value
+ │  │  ││          ├─ attrValue "= D"
+ │  │  ││          ╰─ attrName
+ │  │  │╰─ tagVar.value "a: (B | C)"
+ │  │  ╰─ tagVar "/a: (B | C)"
+ │  ├─ closeTagEnd(let)
+ ╰─ ╰─ tagName "let"
+4╭─ 
+ ╰─ ╰─ openTagEnd
+5╭─ let/a : (B | C) = D
+ │  │  ││           │ ╰─ attrValue.value
+ │  │  ││           ├─ attrValue "= D"
+ │  │  ││           ╰─ attrName
+ │  │  │╰─ tagVar.value "a : (B | C)"
+ │  │  ╰─ tagVar "/a : (B | C)"
+ │  ├─ closeTagEnd(let)
+ ╰─ ╰─ tagName "let"
+6╭─ 
+ ╰─ ╰─ openTagEnd
+7╭─ let/a :(B | C) = D
+ │  │  ││          │ ╰─ attrValue.value
+ │  │  ││          ├─ attrValue "= D"
+ │  │  ││          ╰─ attrName
+ │  │  │╰─ tagVar.value "a :(B | C)"
+ │  │  ╰─ tagVar "/a :(B | C)"
+ │  ├─ closeTagEnd(let)
+ ╰─ ╰─ tagName "let"
+8╭─ 
+ ╰─ ╰─ openTagEnd
+9╭─ let/a: B & (C | D) = D
+ │  │  ││              │ ╰─ attrValue.value
+ │  │  ││              ├─ attrValue "= D"
+ │  │  ││              ╰─ attrName
+ │  │  │╰─ tagVar.value "a: B & (C | D)"
+ │  │  ╰─ tagVar "/a: B & (C | D)"
+ │  ├─ closeTagEnd(let)
+ ╰─ ╰─ tagName "let"
+10╭─ 
+  │  ├─ openTagEnd
+  ╰─ ╰─ closeTagEnd(let)

--- a/src/__tests__/fixtures/tag-var-type-with-parens/input.marko
+++ b/src/__tests__/fixtures/tag-var-type-with-parens/input.marko
@@ -1,0 +1,9 @@
+let/a:(B | C) = D
+
+let/a: (B | C) = D
+
+let/a : (B | C) = D
+
+let/a :(B | C) = D
+
+let/a: B & (C | D) = D

--- a/src/states/EXPRESSION.ts
+++ b/src/states/EXPRESSION.ts
@@ -61,8 +61,23 @@ export const EXPRESSION: StateDefinition<ExpressionMeta> = {
       }
 
       if (expression.shouldTerminate(code, this.data, this.pos)) {
-        this.exitState();
-        return;
+        let wasExpression = false;
+        if (expression.operators) {
+          const prevNonWhitespacePos = lookBehindWhile(
+            isWhitespaceCode,
+            this.data,
+            this.pos - 1
+          );
+          if (prevNonWhitespacePos > expression.start) {
+            wasExpression =
+              lookBehindForOperator(this.data, prevNonWhitespacePos) !== -1;
+          }
+        }
+
+        if (!wasExpression) {
+          this.exitState();
+          return;
+        }
       }
     }
 


### PR DESCRIPTION
## Description

Ensures that in the expression state whenever a terminator is found for the expression and the terminator is preceded by an operator that expression state continues.

## Motivation and Context

This allows for better parsing of expressions in several places. The case that brought about this change was as follows:

```
<let/a:(B | C) = D/>
```

With the above the tag variable state was being terminated by the `(` and going into tag arguments / shorthand default method mode. With this change it will now see the paren and walk backward past whitespace to see the `:` which is an expression operator causing the `(B | C)` to be a part of the tag variable (for types).

## Screenshots (if appropriate):

## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->

<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [ ] I have updated/added documentation affected by my changes.
- [x] I have added tests to cover my changes.
