### PR TITLE
fix: improve detection of regexp vs division

### DIFF
--- a/.changeset/heavy-stingrays-invite.md
+++ b/.changeset/heavy-stingrays-invite.md
@@ -1,0 +1,5 @@
+---
+"htmljs-parser": patch
+---
+
+When the preceding character of an expression is a quote, prefer division over regexp state. This improves parsing for inline css grid properties.

--- a/src/__tests__/fixtures/css-grid/__snapshots__/css-grid.expected.txt
+++ b/src/__tests__/fixtures/css-grid/__snapshots__/css-grid.expected.txt
@@ -1,0 +1,12 @@
+1╭─ ﻿style.scss {
+ │   │    ││    ╰─ attrName "{\n  .foo {\n    grid: \"left right\" / 3fr 7fr;\n  }\n}"
+ │   │    │╰─ tagShorthandClass.quasis[0] "scss"
+ │   │    ╰─ tagShorthandClass ".scss"
+ ╰─  ╰─ tagName "style"
+2├─   .foo {
+3├─     grid: "left right" / 3fr 7fr;
+4├─   }
+5├─ }
+6╭─ 
+ │  ├─ openTagEnd
+ ╰─ ╰─ closeTagEnd(style)

--- a/src/__tests__/fixtures/css-grid/input.marko
+++ b/src/__tests__/fixtures/css-grid/input.marko
@@ -1,0 +1,5 @@
+﻿style.scss {
+  .foo {
+    grid: "left right" / 3fr 7fr;
+  }
+}

--- a/src/states/EXPRESSION.ts
+++ b/src/states/EXPRESSION.ts
@@ -390,15 +390,21 @@ function lookAheadForOperator(data: string, pos: number): number {
 }
 
 function canFollowDivision(code: number) {
-  return (
-    isWordCode(code) ||
-    code === CODE.PERCENT ||
-    code === CODE.CLOSE_PAREN ||
-    code === CODE.PERIOD ||
-    code === CODE.OPEN_ANGLE_BRACKET ||
-    code === CODE.CLOSE_SQUARE_BRACKET ||
-    code === CODE.CLOSE_CURLY_BRACE
-  );
+  if (isWordCode(code)) return true;
+  switch (code) {
+    case CODE.BACKTICK:
+    case CODE.SINGLE_QUOTE:
+    case CODE.DOUBLE_QUOTE:
+    case CODE.PERCENT:
+    case CODE.CLOSE_PAREN:
+    case CODE.PERIOD:
+    case CODE.OPEN_ANGLE_BRACKET:
+    case CODE.CLOSE_SQUARE_BRACKET:
+    case CODE.CLOSE_CURLY_BRACE:
+      return true;
+    default:
+      return false;
+  }
 }
 
 function isWordCode(code: number) {


### PR DESCRIPTION
## Description

Improves the detection of division vs regexp expressions to assume division when the preceding character is a quote.
This improves parsing of css grid properties in particular.

Note in the future this could probably be improved to remove the regexp state altogether for non script sections, but that would require a larger refactor.

## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->

<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [ ] I have updated/added documentation affected by my changes.
- [x] I have added tests to cover my changes.

<!--
Disclaimer: Contributions via GitHub pull requests are gladly accepted from their original author. Along with any pull requests, please state that the contribution is your original work and that you license the work to the project under the project's open source license. Whether or not you state this explicitly, by submitting any copyrighted material via pull request, email, or other means you agree to license the material under the project's open source license and warrant that you have the legal authority to do so.
-->
