### PR TITLE
perf(expression): fast-path identifier characters and short-circuit keyword scans

### DIFF
--- a/.changeset/fast-expressions-skip-scans.md
+++ b/.changeset/fast-expressions-skip-scans.md
@@ -1,0 +1,11 @@
+---
+"htmljs-parser": patch
+---
+
+Speed up expression parsing by skipping work that provably cannot match. An
+identifier/number character is never whitespace, never a terminator (no
+`shouldTerminate` implementation matches a word character), and is not handled
+by the expression switch, so it now takes a fast path that just advances the
+position. The unary/binary operator keyword scans also bail out immediately when
+the surrounding character cannot start or end a keyword. This improves
+steady-state parsing throughput with no behavior change.

--- a/src/states/EXPRESSION.ts
+++ b/src/states/EXPRESSION.ts
@@ -120,6 +120,16 @@ export const EXPRESSION: StateDefinition<ExpressionMeta> = {
         continue;
       }
 
+      // Fast path: an identifier/number character is never whitespace, never
+      // a terminator (no `shouldTerminate` implementation matches a word
+      // character), and is not handled by the switch below, so it just
+      // advances. Short-circuiting here skips the termination checks and the
+      // switch dispatch for the bulk of expression content.
+      if (isWordCode(code)) {
+        this.pos++;
+        continue;
+      }
+
       // Termination checks (no groupStack)
       if (!expression.groupStack.length) {
         if (expression.terminatedByWhitespace && isWhitespaceCode(code)) {
@@ -461,6 +471,10 @@ function lookBehindForOperator(
     }
 
     default: {
+      // Every unary keyword ends in a lowercase letter; if the character
+      // before `pos` is not one, no keyword can match.
+      if (code < CODE.LOWER_A || code > CODE.LOWER_Z) return -1;
+
       for (const keyword of expression.inType
         ? tsUnaryKeywords
         : unaryKeywords) {
@@ -510,6 +524,11 @@ function lookAheadForOperator(
     }
 
     default: {
+      // Every binary keyword starts with a lowercase letter; if the character
+      // at `pos` is not one, no keyword can match.
+      const startCode = data.charCodeAt(pos);
+      if (startCode < CODE.LOWER_A || startCode > CODE.LOWER_Z) return -1;
+
       for (const keyword of binaryKeywords) {
         const keywordPos = lookAheadFor(data, pos, keyword);
         if (keywordPos === -1) continue;


### PR DESCRIPTION
## Summary

Speeds up `EXPRESSION` parsing — the hottest state in the parser (~25% of parse time) — by skipping work that provably cannot match. No behavior change.

### Changes (all in `src/states/EXPRESSION.ts`)

1. **Identifier/number-character fast path.** Inside the per-character loop, a word character (`A-Z a-z 0-9 $ _`) is never whitespace, is never a terminator (no `shouldTerminate` implementation matches a word character), and is not one of the `switch`'s cases — it always falls through to `default: pos++`. A single guard clause now short-circuits the termination checks **and** the switch dispatch for the bulk of expression content:

   ```ts
   if (isWordCode(code)) {
     this.pos++;
     continue;
   }
   ```

2. **Operator keyword-scan short-circuit.** `lookBehindForOperator` / `lookAheadForOperator` looped over the unary/binary keyword lists even when the surrounding character could not possibly start or end a keyword. Since every keyword is lowercase ASCII letters, they now bail out immediately when the relevant character is not `a-z`.

### Correctness

- No behavior change — the full test suite passes, and parser output (a checksum over every emitted range across a 1027-file corpus) is byte-for-byte identical.
- The fast path is safe because every `shouldTerminate` implementation only terminates on punctuation (verified across all implementations), and word characters are not handled by the expression `switch`.

### Performance

Measured with a process-isolated A/B harness (each variant in its own process to avoid JIT cross-talk, alternating order, sign test over many rounds) on a corpus of real Marko fixtures:

- **Steady-state throughput: ~6% faster** vs `main`, with the identifier fast path alone contributing **+3.8% (faster in 20/20 rounds)** on top of the keyword-scan change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01QjE27wdZf9jbWdpV8n227J)_