### PR TITLE
fix(expression): end type annotation at function body brace

### DIFF
--- a/.changeset/statement-fn-return-type-body.md
+++ b/.changeset/statement-fn-return-type-body.md
@@ -1,0 +1,13 @@
+---
+"htmljs-parser": patch
+---
+
+Fix a spurious "Mismatched group" error when a `>` (or other comparison) appears in the body of a statement function that declares a return type, e.g.:
+
+```marko
+export function a(): b {
+  return c > d;
+}
+```
+
+Previously the type-parsing state from the return type annotation leaked into the function body, so a `>` was treated as a closing generic bracket. A `{` that follows a completed type now correctly ends the annotation and parses the block as a value.

--- a/src/__tests__/fixtures/ts-statement-function-return-type/__snapshots__/ts-statement-function-return-type.expected.txt
+++ b/src/__tests__/fixtures/ts-statement-function-return-type/__snapshots__/ts-statement-function-return-type.expected.txt
@@ -1,0 +1,23 @@
+1╭─ export function a(): b {
+ ╰─ ╰─ tagName "export"
+2├─   return c > d;
+3├─ }
+4╭─ 
+ ╰─ ╰─ openTagEnd
+5╭─ static function e<T>(x: T): Array<T> {
+ ╰─ ╰─ tagName "static"
+6├─   return x > 0 ? f : g;
+7├─ }
+8╭─ 
+ ╰─ ╰─ openTagEnd
+9╭─ export function h(): { i: 1 } {
+ ╰─ ╰─ tagName "export"
+10├─   return j > k;
+11├─ }
+12╭─ 
+  ╰─ ╰─ openTagEnd
+13╭─ div
+  ╰─ ╰─ tagName "div"
+14╭─ 
+  │  ├─ openTagEnd
+  ╰─ ╰─ closeTagEnd(div)

--- a/src/__tests__/fixtures/ts-statement-function-return-type/input.marko
+++ b/src/__tests__/fixtures/ts-statement-function-return-type/input.marko
@@ -1,0 +1,13 @@
+export function a(): b {
+  return c > d;
+}
+
+static function e<T>(x: T): Array<T> {
+  return x > 0 ? f : g;
+}
+
+export function h(): { i: 1 } {
+  return j > k;
+}
+
+div

--- a/src/states/EXPRESSION.ts
+++ b/src/states/EXPRESSION.ts
@@ -253,6 +253,16 @@ export const EXPRESSION: StateDefinition<ExpressionMeta> = {
           this.pos++;
           break;
         case CODE.OPEN_CURLY_BRACE:
+          if (expression.inType && !expression.forceType) {
+            const prevPos = lookBehindWhile(
+              isWhitespaceCode,
+              data,
+              this.pos - 1,
+            );
+            if (lookBehindForOperator(expression, data, prevPos) === -1) {
+              expression.inType = false;
+            }
+          }
           expression.groupStack.push(CODE.CLOSE_CURLY_BRACE);
           this.pos++;
           break;


### PR DESCRIPTION
Fixes #215.

A statement function (`export`/`static`) that declares a return type left the parser in "type" mode for the body, so a `>` was parsed as a closing generic bracket:

```marko
export function a(): b {
  return c > d; // Mismatched group. A ">" character was found when "}" was expected.
}
```

A `{` that follows a completed type now ends the annotation and the block is parsed as a value. Object types (`x: { a: 1 }`), generics, and `type`/`interface`/`declare` bodies are unaffected. Adds a regression fixture.


---
_Generated by [Claude Code](https://claude.ai/code/session_01B2kxm4GeBrFGjCq5a8RgbS)_