### PR TITLE
Fix trailing line comment classified as enclosed in validators

### DIFF
--- a/.changeset/tidy-carrots-repair.md
+++ b/.changeset/tidy-carrots-repair.md
@@ -1,0 +1,7 @@
+---
+"htmljs-parser": patch
+---
+
+Fix `isValidAttrValue` (and `isValidStatement` / `isValidScriptlet`) reporting `enclosed` for a value that ends in a trailing `//` line comment (e.g. `"hello" // note`).
+
+A line comment with no terminating newline consumes everything that would follow it on the line, so such a value is not safe to emit verbatim. It is now classified as `valid` (needs wrapping when placed inline), matching the existing behavior for an unguarded trailing newline. A comment guarded by a group (e.g. `("hello" // c\n)`) or a self-closing block comment (`"hello" /* c */`) still classifies as `enclosed`.

--- a/src/__tests__/validate.test.ts
+++ b/src/__tests__/validate.test.ts
@@ -124,5 +124,35 @@ describe("validation helpers", () => {
     it("rejects keyword operator with no operand", () => {
       assert.equal(isValidAttrValue("a as ", true), 0);
     });
+
+    it("treats a trailing line comment as unguarded", () => {
+      assert.equal(isValidAttrValue('"hello" // c', false), 1);
+      assert.equal(isValidAttrValue('"hello" // c', true), 1);
+      assert.equal(isValidAttrValue("foo // c", false), 1);
+      assert.equal(isValidAttrValue("1 + 2 // c", false), 1);
+      assert.equal(isValidAttrValue('"hello" /* c */ // d', false), 1);
+    });
+
+    it("keeps a self-closing block comment enclosed", () => {
+      assert.equal(isValidAttrValue('"hello" /* c */', false), 2);
+    });
+
+    it("keeps a line comment guarded by a group enclosed", () => {
+      assert.equal(isValidAttrValue('("hello" // c\n)', false), 2);
+    });
+
+    it("treats a newline after a value as unguarded", () => {
+      assert.equal(isValidAttrValue('"hello"\n// c', false), 1);
+    });
+  });
+
+  describe("trailing line comments", () => {
+    it("downgrades statements with a trailing line comment", () => {
+      assert.equal(isValidStatement("foo // c"), 1);
+    });
+
+    it("downgrades scriptlets with a trailing line comment", () => {
+      assert.equal(isValidScriptlet("foo // c"), 1);
+    });
   });
 });

--- a/src/states/EXPRESSION.ts
+++ b/src/states/EXPRESSION.ts
@@ -385,6 +385,15 @@ export const EXPRESSION: StateDefinition<ExpressionMeta> = {
   return(child, expression) {
     if (child.state === STATE.JS_COMMENT_LINE) {
       expression.wasComment = true;
+      // A line comment that runs to the end of the input (rather than being
+      // terminated by a newline or a closing tag) consumes everything that
+      // would follow it on the line, exactly like an unguarded newline. Flag
+      // it as unguarded so the value is not classified as `enclosed` (safe to
+      // inline verbatim) by the validation helpers — otherwise emitting it
+      // bare would comment out whatever comes next.
+      if (this.pos === this.maxPos && !expression.groupStack.length) {
+        expression.hadUnguardedNewline = true;
+      }
     }
   },
 };


### PR DESCRIPTION
## Description

Fixes `isValidAttrValue` (and `isValidStatement` / `isValidScriptlet`) reporting `enclosed` for a value that ends in a trailing `//` line comment, e.g. `"hello" // note`.

`isValid` only downgraded `enclosed` → `valid` when it scanned a literal newline byte. A line comment that runs to EOF contains no newline, so `hadUnguardedNewline` never tripped and the value stayed `enclosed`. But a trailing line comment consumes everything that would follow it on the line, so the value is **not** safe to emit verbatim.

The fix flags the enclosing expression as having an unguarded newline when a line comment reaches EOF while no group is open — mirroring the existing unguarded-newline handling. It lives in `EXPRESSION.return`, so it only affects line comments whose parent is a JS expression (not the same state entered from tag/HTML contexts).

| input | before | after |
| --- | --- | --- |
| `"hello" // c` | `enclosed` | `valid` |
| `foo // c` | `enclosed` | `valid` |
| `1 + 2 // c` | `enclosed` | `valid` |
| `"hello" /* c */ // d` | `enclosed` | `valid` |
| `"hello" /* c */` | `enclosed` | `enclosed` (block comment self-closes) |
| `("hello" // c\n)` | `enclosed` | `enclosed` (guarded by parens) |
| `"hello"\n// c` | `valid` | `valid` |

## Motivation and Context

Regression introduced in 5.11.0 (last good: 5.10.2). `enclosed` promises consumers "safe to emit verbatim, no wrapping needed" — so `prettier-plugin-marko` emitted such values bare, ejecting the comment and commenting out the tag close:

```marko
<!-- input -->
<custom-tag id=("hello" // this comment should not be removed")/>

<!-- broken output: comment ejected, would comment out the tag close -->
<custom-tag id="hello"/> // this comment should not be removed
```

## Checklist:

- [ ] I have updated/added documentation affected by my changes.
- [x] I have added tests to cover my changes.


---
_Generated by [Claude Code](https://claude.ai/code/session_01CSWH3bbqQnBKeFZbW5mpoJ)_